### PR TITLE
tackle-148-stakeholder-duplication

### DIFF
--- a/.github/scripts/check_api.sh
+++ b/.github/scripts/check_api.sh
@@ -75,6 +75,47 @@ curl -X PATCH "http://$api_ip/pathfinder/assessments/$assessmentId" -H 'Accept: 
             -d "{ \"id\": $assessmentId,\"status\": \"STARTED\",\"stakeholders\": [77,44],\"stakeholderGroups\": [333,222,111],\"questionnaire\": {\"categories\": [{\"id\": $categoryid,\"comment\" : \"This is a test comment\",\"questions\": [{\"id\": $questionid,\"options\": [{\"id\": $optionid,\"checked\": true}]}]}]}}" \
              | grep '"applicationId":100,"status":"STARTED"}200'
 
+# Updating several times to check no duplication
+curl -X PATCH "http://$api_ip/pathfinder/assessments/$assessmentId" -H 'Accept: application/json' \
+            -H "Authorization: Bearer $access_token" -w "%{http_code}" \
+            -H 'Content-Type: application/json' \
+            -d "{ \"id\": $assessmentId,\"status\": \"STARTED\",\"stakeholders\": [77,44],\"stakeholderGroups\": [333,222,111],\"questionnaire\": {\"categories\": [{\"id\": $categoryid,\"comment\" : \"This is a test comment\",\"questions\": [{\"id\": $questionid,\"options\": [{\"id\": $optionid,\"checked\": true}]}]}]}}" \
+             | grep '"applicationId":100,"status":"STARTED"}200'
+curl -X PATCH "http://$api_ip/pathfinder/assessments/$assessmentId" -H 'Accept: application/json' \
+            -H "Authorization: Bearer $access_token" -w "%{http_code}" \
+            -H 'Content-Type: application/json' \
+            -d "{ \"id\": $assessmentId,\"status\": \"STARTED\",\"stakeholders\": [77,44],\"stakeholderGroups\": [333,222,111,444],\"questionnaire\": {\"categories\": [{\"id\": $categoryid,\"comment\" : \"This is a test comment\",\"questions\": [{\"id\": $questionid,\"options\": [{\"id\": $optionid,\"checked\": true}]}]}]}}" \
+             | grep '"applicationId":100,"status":"STARTED"}200'
+assessment_reupdated_json=$(curl -X GET "http://$api_ip/pathfinder/assessments/$assessmentId" -H 'Accept: application/json' \
+            -H "Authorization: Bearer $access_token" -s)
+echo '++ 8.1 Test stakeholders=2 , groups =4 '
+test "$(echo $assessment_reupdated_json | jq '.stakeholders | length ')" = "2"
+test "$(echo $assessment_reupdated_json | jq '.stakeholderGroups | length')" = "4"
+
+# Updating with deleting all stakeholders and 2 stakeholdergroup
+curl -X PATCH "http://$api_ip/pathfinder/assessments/$assessmentId" -H 'Accept: application/json' \
+            -H "Authorization: Bearer $access_token" -w "%{http_code}" \
+            -H 'Content-Type: application/json' \
+            -d "{ \"id\": $assessmentId,\"status\": \"STARTED\",\"stakeholders\": [],\"stakeholderGroups\": [333,222],\"questionnaire\": {\"categories\": [{\"id\": $categoryid,\"comment\" : \"This is a test comment\",\"questions\": [{\"id\": $questionid,\"options\": [{\"id\": $optionid,\"checked\": true}]}]}]}}" \
+             | grep '"applicationId":100,"status":"STARTED"}200'
+assessment_reupdated_json=$(curl -X GET "http://$api_ip/pathfinder/assessments/$assessmentId" -H 'Accept: application/json' \
+            -H "Authorization: Bearer $access_token" -s)
+echo '++ 8.2 Test stakeholders=0 , groups =2 '
+test "$(echo $assessment_reupdated_json | jq '.stakeholders | length ')" = "0"
+test "$(echo $assessment_reupdated_json | jq '.stakeholderGroups | length')" = "2"
+
+# Updating with seting 1 stakeholders and not touching stakeholdergroups
+curl -X PATCH "http://$api_ip/pathfinder/assessments/$assessmentId" -H 'Accept: application/json' \
+            -H "Authorization: Bearer $access_token" -w "%{http_code}" \
+            -H 'Content-Type: application/json' \
+            -d "{ \"id\": $assessmentId,\"status\": \"STARTED\",\"stakeholders\": [666],\"questionnaire\": {\"categories\": [{\"id\": $categoryid,\"comment\" : \"This is a test comment\",\"questions\": [{\"id\": $questionid,\"options\": [{\"id\": $optionid,\"checked\": true}]}]}]}}" \
+             | grep '"applicationId":100,"status":"STARTED"}200'
+assessment_reupdated_json=$(curl -X GET "http://$api_ip/pathfinder/assessments/$assessmentId" -H 'Accept: application/json' \
+            -H "Authorization: Bearer $access_token" -s)
+echo '++ 8.3 Test stakeholders=1 , groups =2 '
+test "$(echo $assessment_reupdated_json | jq '.stakeholders | length ')" = "1"
+test "$(echo $assessment_reupdated_json | jq '.stakeholderGroups | length')" = "2"
+
 echo
 echo
 echo '9 >>> Give an updated assessment, check values have been successfully stored'

--- a/.github/scripts/check_api.sh
+++ b/.github/scripts/check_api.sh
@@ -72,19 +72,19 @@ echo '8 >>> Given an assessment, update few values and check return value is 200
 curl -X PATCH "http://$api_ip/pathfinder/assessments/$assessmentId" -H 'Accept: application/json' \
             -H "Authorization: Bearer $access_token" -w "%{http_code}" \
             -H 'Content-Type: application/json' \
-            -d "{ \"id\": $assessmentId,\"status\": \"STARTED\",\"stakeholders\": [77,44],\"stakeholderGroups\": [333,222,111],\"questionnaire\": {\"categories\": [{\"id\": $categoryid,\"comment\" : \"This is a test comment\",\"questions\": [{\"id\": $questionid,\"options\": [{\"id\": $optionid,\"checked\": true}]}]}]}}" \
+            -d "{ \"id\": $assessmentId,\"status\": \"STARTED\",\"stakeholders\": [9977,9944],\"stakeholderGroups\": [99333,99222,99111],\"questionnaire\": {\"categories\": [{\"id\": $categoryid,\"comment\" : \"This is a test comment\",\"questions\": [{\"id\": $questionid,\"options\": [{\"id\": $optionid,\"checked\": true}]}]}]}}" \
              | grep '"applicationId":100,"status":"STARTED"}200'
 
 # Updating several times to check no duplication
 curl -X PATCH "http://$api_ip/pathfinder/assessments/$assessmentId" -H 'Accept: application/json' \
             -H "Authorization: Bearer $access_token" -w "%{http_code}" \
             -H 'Content-Type: application/json' \
-            -d "{ \"id\": $assessmentId,\"status\": \"STARTED\",\"stakeholders\": [77,44],\"stakeholderGroups\": [333,222,111],\"questionnaire\": {\"categories\": [{\"id\": $categoryid,\"comment\" : \"This is a test comment\",\"questions\": [{\"id\": $questionid,\"options\": [{\"id\": $optionid,\"checked\": true}]}]}]}}" \
+            -d "{ \"id\": $assessmentId,\"status\": \"STARTED\",\"stakeholders\": [9977,9944],\"stakeholderGroups\": [99333,99222,99111],\"questionnaire\": {\"categories\": [{\"id\": $categoryid,\"comment\" : \"This is a test comment\",\"questions\": [{\"id\": $questionid,\"options\": [{\"id\": $optionid,\"checked\": true}]}]}]}}" \
              | grep '"applicationId":100,"status":"STARTED"}200'
 curl -X PATCH "http://$api_ip/pathfinder/assessments/$assessmentId" -H 'Accept: application/json' \
             -H "Authorization: Bearer $access_token" -w "%{http_code}" \
             -H 'Content-Type: application/json' \
-            -d "{ \"id\": $assessmentId,\"status\": \"STARTED\",\"stakeholders\": [77,44],\"stakeholderGroups\": [333,222,111,444],\"questionnaire\": {\"categories\": [{\"id\": $categoryid,\"comment\" : \"This is a test comment\",\"questions\": [{\"id\": $questionid,\"options\": [{\"id\": $optionid,\"checked\": true}]}]}]}}" \
+            -d "{ \"id\": $assessmentId,\"status\": \"STARTED\",\"stakeholders\": [9977,9944],\"stakeholderGroups\": [99333,99222,99111,99444],\"questionnaire\": {\"categories\": [{\"id\": $categoryid,\"comment\" : \"This is a test comment\",\"questions\": [{\"id\": $questionid,\"options\": [{\"id\": $optionid,\"checked\": true}]}]}]}}" \
              | grep '"applicationId":100,"status":"STARTED"}200'
 assessment_reupdated_json=$(curl -X GET "http://$api_ip/pathfinder/assessments/$assessmentId" -H 'Accept: application/json' \
             -H "Authorization: Bearer $access_token" -s)
@@ -96,7 +96,7 @@ test "$(echo $assessment_reupdated_json | jq '.stakeholderGroups | length')" = "
 curl -X PATCH "http://$api_ip/pathfinder/assessments/$assessmentId" -H 'Accept: application/json' \
             -H "Authorization: Bearer $access_token" -w "%{http_code}" \
             -H 'Content-Type: application/json' \
-            -d "{ \"id\": $assessmentId,\"status\": \"STARTED\",\"stakeholders\": [],\"stakeholderGroups\": [333,222],\"questionnaire\": {\"categories\": [{\"id\": $categoryid,\"comment\" : \"This is a test comment\",\"questions\": [{\"id\": $questionid,\"options\": [{\"id\": $optionid,\"checked\": true}]}]}]}}" \
+            -d "{ \"id\": $assessmentId,\"status\": \"STARTED\",\"stakeholders\": [],\"stakeholderGroups\": [99333,99222],\"questionnaire\": {\"categories\": [{\"id\": $categoryid,\"comment\" : \"This is a test comment\",\"questions\": [{\"id\": $questionid,\"options\": [{\"id\": $optionid,\"checked\": true}]}]}]}}" \
              | grep '"applicationId":100,"status":"STARTED"}200'
 assessment_reupdated_json=$(curl -X GET "http://$api_ip/pathfinder/assessments/$assessmentId" -H 'Accept: application/json' \
             -H "Authorization: Bearer $access_token" -s)
@@ -171,7 +171,7 @@ optionSourceid=$(echo $assessmentSource_json | jq '.questionnaire.categories[0].
 curl -X PATCH "http://$api_ip/pathfinder/assessments/$assessmentSourceId" -H 'Accept: application/json' \
             -H "Authorization: Bearer $access_token" -w "%{http_code}" \
             -H 'Content-Type: application/json' \
-            -d "{ \"status\": \"STARTED\",\"stakeholders\": [77,44],\"stakeholderGroups\": [333,222,111],\"questionnaire\": {\"categories\": [{\"id\": $categorySourceid,\"comment\" : \"This is a test comment\",\"questions\": [{\"id\": $questionSourceid,\"options\": [{\"id\": $optionSourceid,\"checked\": true}]}]},{\"id\": $categorySourceSecondid,\"comment\" : \"This is a test comment\"}]}}" \
+            -d "{ \"status\": \"STARTED\",\"stakeholders\": [9877,9844],\"stakeholderGroups\": [98333,98222,98111],\"questionnaire\": {\"categories\": [{\"id\": $categorySourceid,\"comment\" : \"This is a test comment\",\"questions\": [{\"id\": $questionSourceid,\"options\": [{\"id\": $optionSourceid,\"checked\": true}]}]},{\"id\": $categorySourceSecondid,\"comment\" : \"This is a test comment\"}]}}" \
              | grep "\"applicationId\":$applicationSource,\"status\":\"STARTED\"}200"
 
 # Get updated assessment

--- a/.github/scripts/check_api.sh
+++ b/.github/scripts/check_api.sh
@@ -121,8 +121,8 @@ echo
 echo '9 >>> Give an updated assessment, check values have been successfully stored'
 assessment_updated_json=$(curl -X GET "http://$api_ip/pathfinder/assessments/$assessmentId" -H 'Accept: application/json' \
             -H "Authorization: Bearer $access_token" -s)
-test "$(echo $assessment_updated_json | jq '.stakeholders | length')" = "2"
-test "$(echo $assessment_updated_json | jq '.stakeholderGroups | length')" = "3"
+test "$(echo $assessment_updated_json | jq '.stakeholders | length')" = "1"
+test "$(echo $assessment_updated_json | jq '.stakeholderGroups | length')" = "2"
 test "$(echo $assessment_updated_json | jq ".questionnaire.categories[] | select(.id == $categoryid) | .comment // \"empty\"")" = '"This is a test comment"'
 test "$(echo $assessment_updated_json | jq ".questionnaire.categories[] | select(.id == $categoryid) | .questions[] | select(.id == $questionid) | .options[] | select(.id == $optionid) | .checked")" = "true"
 

--- a/.github/scripts/check_api.sh
+++ b/.github/scripts/check_api.sh
@@ -84,12 +84,12 @@ curl -X PATCH "http://$api_ip/pathfinder/assessments/$assessmentId" -H 'Accept: 
 curl -X PATCH "http://$api_ip/pathfinder/assessments/$assessmentId" -H 'Accept: application/json' \
             -H "Authorization: Bearer $access_token" -w "%{http_code}" \
             -H 'Content-Type: application/json' \
-            -d "{ \"id\": $assessmentId,\"status\": \"STARTED\",\"stakeholders\": [9977,9944],\"stakeholderGroups\": [99333,99222,99111,99444],\"questionnaire\": {\"categories\": [{\"id\": $categoryid,\"comment\" : \"This is a test comment\",\"questions\": [{\"id\": $questionid,\"options\": [{\"id\": $optionid,\"checked\": true}]}]}]}}" \
+            -d "{ \"id\": $assessmentId,\"status\": \"STARTED\",\"stakeholders\": [9977,9944,9933],\"stakeholderGroups\": [99333,99222,99111,99444],\"questionnaire\": {\"categories\": [{\"id\": $categoryid,\"comment\" : \"This is a test comment\",\"questions\": [{\"id\": $questionid,\"options\": [{\"id\": $optionid,\"checked\": true}]}]}]}}" \
              | grep '"applicationId":100,"status":"STARTED"}200'
 assessment_reupdated_json=$(curl -X GET "http://$api_ip/pathfinder/assessments/$assessmentId" -H 'Accept: application/json' \
             -H "Authorization: Bearer $access_token" -s)
-echo '++ 8.1 Test stakeholders=2 , groups =4 '
-test "$(echo $assessment_reupdated_json | jq '.stakeholders | length ')" = "2"
+echo '++ 8.1 Test stakeholders=3 , groups =4 '
+test "$(echo $assessment_reupdated_json | jq '.stakeholders | length ')" = "3"
 test "$(echo $assessment_reupdated_json | jq '.stakeholderGroups | length')" = "4"
 
 # Updating with deleting all stakeholders and 2 stakeholdergroup

--- a/src/main/java/io/tackle/pathfinder/dto/AssessmentDto.java
+++ b/src/main/java/io/tackle/pathfinder/dto/AssessmentDto.java
@@ -66,16 +66,14 @@ public class AssessmentDto {
      */
     @JsonProperty("stakeholders")
     @JsonPropertyDescription("List of ids of stakeholders")
-    @Builder.Default
-    private List<Long> stakeholders = new ArrayList<Long>();
+    private List<Long> stakeholders ;
     /**
      * List of ids of stakeholder groups
      * 
      */
     @JsonProperty("stakeholderGroups")
     @JsonPropertyDescription("List of ids of stakeholder groups")
-    @Builder.Default
-    private List<Long> stakeholderGroups = new ArrayList<Long>();
+    private List<Long> stakeholderGroups;
     /**
      * 
      * (Required)

--- a/src/main/java/io/tackle/pathfinder/model/assessment/Assessment.java
+++ b/src/main/java/io/tackle/pathfinder/model/assessment/Assessment.java
@@ -41,14 +41,14 @@ public class Assessment extends AbstractEntity {
     @Column(length = 1000)
     public String comment;
 
-    @OneToOne(mappedBy = "assessment", cascade = CascadeType.REMOVE)
+    @OneToOne(mappedBy = "assessment", cascade = CascadeType.ALL)
     public AssessmentQuestionnaire assessmentQuestionnaire;
 
-    @OneToMany(mappedBy = "assessment", cascade = CascadeType.REMOVE)
+    @OneToMany(mappedBy = "assessment", cascade = CascadeType.ALL)
     @Builder.Default
     public List<AssessmentStakeholder> stakeholders= new ArrayList<>();
 
-    @OneToMany(mappedBy = "assessment", cascade = CascadeType.REMOVE)
+    @OneToMany(mappedBy = "assessment", cascade = CascadeType.ALL)
     @Builder.Default
     public List<AssessmentStakeholdergroup> stakeholdergroups = new ArrayList<>();
 }

--- a/src/main/java/io/tackle/pathfinder/model/assessment/AssessmentCategory.java
+++ b/src/main/java/io/tackle/pathfinder/model/assessment/AssessmentCategory.java
@@ -32,7 +32,7 @@ public class AssessmentCategory extends AbstractEntity {
 
     public String name;
 
-    @OneToMany(mappedBy = "category", cascade = CascadeType.REMOVE)
+    @OneToMany(mappedBy = "category", cascade = CascadeType.ALL)
     @Builder.Default
     public List<AssessmentQuestion> questions=new ArrayList<>();
 

--- a/src/main/java/io/tackle/pathfinder/model/assessment/AssessmentQuestion.java
+++ b/src/main/java/io/tackle/pathfinder/model/assessment/AssessmentQuestion.java
@@ -46,7 +46,7 @@ public class AssessmentQuestion extends AbstractEntity {
     @Column(name="question_text", length = 500 )
     public String questionText;
 
-    @OneToMany(mappedBy="question", cascade = CascadeType.REMOVE)
+    @OneToMany(mappedBy="question", cascade = CascadeType.ALL)
     @Builder.Default
     public List<AssessmentSingleOption> singleOptions=new ArrayList<>();
 

--- a/src/main/java/io/tackle/pathfinder/model/assessment/AssessmentQuestionnaire.java
+++ b/src/main/java/io/tackle/pathfinder/model/assessment/AssessmentQuestionnaire.java
@@ -41,7 +41,7 @@ public class AssessmentQuestionnaire extends AbstractEntity {
     @JoinColumn(name = "assessment_id", referencedColumnName="id", nullable = false)
     public Assessment assessment;
 
-    @OneToMany(mappedBy="questionnaire", cascade = CascadeType.REMOVE)
+    @OneToMany(mappedBy="questionnaire", cascade = CascadeType.ALL)
     @Builder.Default
     public List<AssessmentCategory> categories=new ArrayList<>();
 

--- a/src/main/java/io/tackle/pathfinder/services/AssessmentSvc.java
+++ b/src/main/java/io/tackle/pathfinder/services/AssessmentSvc.java
@@ -137,40 +137,44 @@ public class AssessmentSvc {
         if (null != assessmentDto.getStakeholderGroups()) {
             // Delete existing stakeholdergroups not included in current array
             assessment.stakeholdergroups.forEach(stakegroup -> {
-                if (!assessmentDto.getStakeholderGroups().contains(stakegroup.stakeholdergroupId)) {
+                if (assessmentDto.getStakeholderGroups().stream().noneMatch(f -> f.equals(stakegroup.stakeholdergroupId))) {
                     log.log(Level.FINE,"Deleted stakegroup : " + stakegroup.stakeholdergroupId);
                     stakegroup.delete();
                 }
             });
+            assessment.stakeholdergroups.removeIf(e -> assessmentDto.getStakeholderGroups().stream().noneMatch(f -> f.equals(e.stakeholdergroupId)));
+
             // Add not existing stakeholdergroups included in the current array
             assessmentDto.getStakeholderGroups().forEach(e -> {
                 log.log(Level.FINE, "Considering Stakeholdergroup : " + e);
                 if (assessment.stakeholdergroups.stream().noneMatch(o -> e.equals(o.stakeholdergroupId))) {
                     log.log(Level.FINE,"Adding Stakeholdergroup : " + e);
-                    AssessmentStakeholdergroup.builder()
+                    assessment.stakeholdergroups.add(AssessmentStakeholdergroup.builder()
                             .assessment(assessment)
                             .stakeholdergroupId(e)
-                            .build().persist();
+                            .build());
                 }
             });
         }
         if (null != assessmentDto.getStakeholders()) {
             // Delete existing stakeholders not included in current array
             assessment.stakeholders.forEach(stake -> {
-                if (!assessmentDto.getStakeholders().contains(stake.stakeholderId)) {
+                if (assessmentDto.getStakeholders().stream().noneMatch(f -> f.equals(stake.stakeholderId))) {
                     log.log(Level.FINE,"Deleted stake : " + stake.stakeholderId);
                     stake.delete();
                 }
             });
+            assessment.stakeholders.removeIf(e -> assessmentDto.getStakeholders().stream().noneMatch(f -> f.equals(e.stakeholderId)));
+
             // Add not existing stakeholders included in the current array
             assessmentDto.getStakeholders().forEach(e -> {
                 log.log(Level.FINE,"Considering Stakeholder : " + e);
                 if (assessment.stakeholders.stream().noneMatch(o -> e.equals(o.stakeholderId))) {
                     log.log(Level.FINE,"Adding Stakeholder : " + e);
-                    AssessmentStakeholder.builder()
+                    assessment.stakeholders.add(AssessmentStakeholder.builder()
                         .assessment(assessment)
                         .stakeholderId(e)
-                        .build().persist();
+                        .build());
                 }
             });
         }
@@ -200,7 +204,6 @@ public class AssessmentSvc {
                 }
             });
         }
-
         return mapper.assessmentToAssessmentHeaderDto(assessment);
     }
 

--- a/src/main/java/io/tackle/pathfinder/services/AssessmentSvc.java
+++ b/src/main/java/io/tackle/pathfinder/services/AssessmentSvc.java
@@ -145,7 +145,7 @@ public class AssessmentSvc {
             // Add not existing stakeholdergroups included in the current array
             assessmentDto.getStakeholderGroups().forEach(e -> {
                 log.log(Level.FINE, "Considering Stakeholdergroup : " + e);
-                if (assessment.stakeholdergroups.stream().noneMatch(o -> o.stakeholdergroupId == e)) {
+                if (assessment.stakeholdergroups.stream().noneMatch(o -> e.equals(o.stakeholdergroupId))) {
                     log.log(Level.FINE,"Adding Stakeholdergroup : " + e);
                     AssessmentStakeholdergroup.builder()
                             .assessment(assessment)
@@ -165,7 +165,7 @@ public class AssessmentSvc {
             // Add not existing stakeholders included in the current array
             assessmentDto.getStakeholders().forEach(e -> {
                 log.log(Level.FINE,"Considering Stakeholder : " + e);
-                if (assessment.stakeholders.stream().noneMatch(o -> o.stakeholderId == e)) {
+                if (assessment.stakeholders.stream().noneMatch(o -> e.equals(o.stakeholderId))) {
                     log.log(Level.FINE,"Adding Stakeholder : " + e);
                     AssessmentStakeholder.builder()
                         .assessment(assessment)

--- a/src/main/resources/db/migration/V0.0.2_007__add_stakeholder_index.sql
+++ b/src/main/resources/db/migration/V0.0.2_007__add_stakeholder_index.sql
@@ -1,0 +1,9 @@
+-- Only unique stakeholders allowed per assessment
+CREATE UNIQUE INDEX assesment_stakeholder_unique_idx
+ON assessment_stakeholder (assessment_id, stakeholder_id)
+WHERE (deleted is not true);
+
+-- Only unique stakeholders allowed per assessment
+CREATE UNIQUE INDEX assesment_stakeholdergroup_unique_idx
+ON assessment_stakeholdergroup (assessment_id, stakeholdergroup_id)
+WHERE (deleted is not true);

--- a/src/test/java/io/tackle/pathfinder/controllers/AssessmentsResourceTest.java
+++ b/src/test/java/io/tackle/pathfinder/controllers/AssessmentsResourceTest.java
@@ -372,7 +372,8 @@ public class AssessmentsResourceTest extends SecuredResourceTest {
 			.log().all()
 			.statusCode(200)
 			.body("status", is("COMPLETE"));
-	}	
+	}
+
 	@Test
 	public void given_AssessmentCreated_When_UpdatingStatusWithWrongValue_Then_ResponseIs400() {
 		// Creation of the Assessment
@@ -492,7 +493,8 @@ public class AssessmentsResourceTest extends SecuredResourceTest {
 		.then()
 			.log().all()
 			.statusCode(404);
-	}	
+	}
+
 	@Test
 	public void given_AssessmentDeleted_When_Deleting_Then_ResponseIs404() {
 		// Creation of the Assessment
@@ -547,8 +549,6 @@ public class AssessmentsResourceTest extends SecuredResourceTest {
     		.log().all()
 			.statusCode(404);
 	}
-
-
 
 	@Transactional
 	public void addUserEnteredInfoToAssessment(Long assessmentId) {
@@ -651,6 +651,7 @@ public class AssessmentsResourceTest extends SecuredResourceTest {
 				.ignoringCollectionOrder()
 				.isEqualTo(assessmentSource);
 	}
+
 	@Test
 	public void given_ApplicationAssessed_When_CopyAssessmentToAnotherAssessedApp_Then_BadRequestIsAssessed() {
 		// Creation of the Assessment
@@ -686,6 +687,7 @@ public class AssessmentsResourceTest extends SecuredResourceTest {
 			.log().all()
 			.statusCode(400);
 	}
+
 	@Test
 	public void given_ApplicationAssessedButDeleted_When_CopyAssessmentToAnotherAssessedApp_Then_404NotFoundIsReturned() {
 		// Creation of the Assessment
@@ -720,7 +722,8 @@ public class AssessmentsResourceTest extends SecuredResourceTest {
 		.then()
 			.log().all()
 			.statusCode(404);
-	}	
+	}
+
 	@Test
 	public void given_ApplicationNotAssessed_When_CopyAssessmentToAnotherNotAssessedApp_Then_BadRequestIsAssessed() {
 		//Copy of the Assessment, and expect to fail

--- a/src/test/java/io/tackle/pathfinder/controllers/AssessmentsResourceTest.java
+++ b/src/test/java/io/tackle/pathfinder/controllers/AssessmentsResourceTest.java
@@ -651,7 +651,7 @@ public class AssessmentsResourceTest extends SecuredResourceTest {
 				.ignoringCollectionOrder()
 				.isEqualTo(assessmentSource);
 	}
-
+	@Test
 	public void given_ApplicationAssessed_When_CopyAssessmentToAnotherAssessedApp_Then_BadRequestIsAssessed() {
 		// Creation of the Assessment
 		AssessmentHeaderDto assessmentHeader = given()
@@ -686,7 +686,7 @@ public class AssessmentsResourceTest extends SecuredResourceTest {
 			.log().all()
 			.statusCode(400);
 	}
-	
+	@Test
 	public void given_ApplicationAssessedButDeleted_When_CopyAssessmentToAnotherAssessedApp_Then_404NotFoundIsReturned() {
 		// Creation of the Assessment
 		AssessmentHeaderDto header = given()
@@ -716,12 +716,12 @@ public class AssessmentsResourceTest extends SecuredResourceTest {
 			.accept(ContentType.JSON)
 			.body(new ApplicationDto(389500L))
 		.when()
-			.post("/assessments/fromAssessmentId=" + header.getId())
+			.post("/assessments?fromAssessmentId=" + header.getId())
 		.then()
 			.log().all()
 			.statusCode(404);
 	}	
-	
+	@Test
 	public void given_ApplicationNotAssessed_When_CopyAssessmentToAnotherNotAssessedApp_Then_BadRequestIsAssessed() {
 		//Copy of the Assessment, and expect to fail
 		given()

--- a/src/test/java/io/tackle/pathfinder/services/AssessmentSvcTest.java
+++ b/src/test/java/io/tackle/pathfinder/services/AssessmentSvcTest.java
@@ -169,6 +169,38 @@ public class AssessmentSvcTest {
         Assessment assessmentUpdated = Assessment.findById(assessment.id);
         assertThat(assessmentUpdated.stakeholders).extracting(e -> e.stakeholderId).containsExactlyInAnyOrder(100L, 200L, 300L);
         assertThat(assessmentUpdated.stakeholdergroups).extracting(e -> e.stakeholdergroupId).containsExactlyInAnyOrder(500L, 600L);
+    }
+
+    @Test
+    public void given_CreatedAssessment_When_UpdateSeveralTimes_Then_StakeholdersAreNotDuplicated() throws InterruptedException {
+        Assessment assessment = createAssessment(Questionnaire.findAll().firstResult(), 2415L);
+
+        assertThat(assessment.stakeholders).extracting(e -> e.stakeholderId).containsExactlyInAnyOrder(100L, 200L, 300L);
+        assertThat(assessment.stakeholdergroups).extracting(e -> e.stakeholdergroupId).containsExactlyInAnyOrder(500L, 600L);
+
+        AssessmentDto assessmentDto = assessmentMapper.assessmentToAssessmentDto(assessment);
+        assertThat(assessmentDto.getStakeholderGroups()).hasSize(2);
+        assertThat(assessmentDto.getStakeholders()).hasSize(3); 
+
+        // Stakeholders and Stakeholdergroups NOT send will imply leave what is there without touching it
+        assessmentDto.setStakeholderGroups(null);
+        assessmentDto.setStakeholders(null);
+
+        assessmentSvc.updateAssessment(assessment.id, assessmentDto);
+
+        Assessment assessmentUpdated = Assessment.findById(assessment.id);
+        assertThat(assessmentUpdated.stakeholders).extracting(e -> e.stakeholderId).containsExactlyInAnyOrder(100L, 200L, 300L);
+        assertThat(assessmentUpdated.stakeholdergroups).extracting(e -> e.stakeholdergroupId).containsExactlyInAnyOrder(500L, 600L);
+        
+        assessmentSvc.updateAssessment(assessment.id, assessmentDto);
+        assessmentUpdated = Assessment.findById(assessment.id);
+        assertThat(assessmentUpdated.stakeholders).extracting(e -> e.stakeholderId).containsExactlyInAnyOrder(100L, 200L, 300L);
+        assertThat(assessmentUpdated.stakeholdergroups).extracting(e -> e.stakeholdergroupId).containsExactlyInAnyOrder(500L, 600L);        
+        
+        assessmentSvc.updateAssessment(assessment.id, assessmentDto);
+        assessmentUpdated = Assessment.findById(assessment.id);
+        assertThat(assessmentUpdated.stakeholders).extracting(e -> e.stakeholderId).containsExactlyInAnyOrder(100L, 200L, 300L);
+        assertThat(assessmentUpdated.stakeholdergroups).extracting(e -> e.stakeholdergroupId).containsExactlyInAnyOrder(500L, 600L);
     }    
     
     @Test

--- a/src/test/java/io/tackle/pathfinder/services/AssessmentSvcTest.java
+++ b/src/test/java/io/tackle/pathfinder/services/AssessmentSvcTest.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import javax.inject.Inject;
-import javax.transaction.Transactional;
+import javax.transaction.*;
 import javax.ws.rs.BadRequestException;
 
 import java.time.Duration;
@@ -64,7 +64,8 @@ public class AssessmentSvcTest {
     @Inject
     AssessmentMapper assessmentMapper;
 
-
+    @Inject
+    UserTransaction transaction;
 
     @Test
     @Transactional
@@ -111,6 +112,7 @@ public class AssessmentSvcTest {
     }
 
     @Test
+    @Transactional
     public void given_CreatedAssessment_When_Update_Then_ItChangesOnlyThePartSent() throws InterruptedException {
         Assessment assessment = createAssessment(Questionnaire.findAll().firstResult(), 1410L);
 
@@ -150,6 +152,7 @@ public class AssessmentSvcTest {
     }
 
     @Test
+    @Transactional
     public void given_CreatedAssessment_When_UpdateWithStakeholdersNull_Then_ItDoesntChangeStakeholders() throws InterruptedException {
         Assessment assessment = createAssessment(Questionnaire.findAll().firstResult(), 2410L);
 
@@ -172,6 +175,7 @@ public class AssessmentSvcTest {
     }
 
     @Test
+    @Transactional
     public void given_CreatedAssessment_When_UpdateSeveralTimes_Then_StakeholdersAreNotDuplicated() throws InterruptedException {
         Assessment assessment = createAssessment(Questionnaire.findAll().firstResult(), 2415L);
 
@@ -193,20 +197,24 @@ public class AssessmentSvcTest {
         assertThat(assessmentUpdated.stakeholdergroups).extracting(e -> e.stakeholdergroupId).containsExactlyInAnyOrder(500L, 600L);
         
         // adding again the same original list to the dtos, should not change anything as we are adding the same ones it contains
-        assessmentDto.setStakeholderGroups(List.of(500L, 600L));
-        assessmentDto.setStakeholders(List.of(100L, 200L, 300L));
+        assessmentDto.setStakeholders(List.of(180L, 200L, 300L, 800L));
+        assessmentDto.setStakeholderGroups(List.of(550L, 650L, 750L));
+
         assessmentSvc.updateAssessment(assessment.id, assessmentDto);
+
         assessmentUpdated = Assessment.findById(assessment.id);
-        assertThat(assessmentUpdated.stakeholders).extracting(e -> e.stakeholderId).containsExactlyInAnyOrder(100L, 200L, 300L);
-        assertThat(assessmentUpdated.stakeholdergroups).extracting(e -> e.stakeholdergroupId).containsExactlyInAnyOrder(500L, 600L);        
+        assertThat(assessmentUpdated.stakeholders).extracting(e -> e.stakeholderId).containsExactlyInAnyOrder(180L, 200L, 300L, 800L);
+        assertThat(assessmentUpdated.stakeholdergroups).extracting(e -> e.stakeholdergroupId).containsExactlyInAnyOrder(550L, 650L, 750L);
         
         assessmentSvc.updateAssessment(assessment.id, assessmentDto);
+
         assessmentUpdated = Assessment.findById(assessment.id);
-        assertThat(assessmentUpdated.stakeholders).extracting(e -> e.stakeholderId).containsExactlyInAnyOrder(100L, 200L, 300L);
-        assertThat(assessmentUpdated.stakeholdergroups).extracting(e -> e.stakeholdergroupId).containsExactlyInAnyOrder(500L, 600L);
+        assertThat(assessmentUpdated.stakeholders).extracting(e -> e.stakeholderId).containsExactlyInAnyOrder(180L, 200L, 300L, 800L);
+        assertThat(assessmentUpdated.stakeholdergroups).extracting(e -> e.stakeholdergroupId).containsExactlyInAnyOrder(550L, 650L, 750L);
     }    
     
     @Test
+    @Transactional
     public void given_CreatedAssessment_When_UpdateWithStakeholdersEmpty_Then_ItDeleteAllStakeholders() throws InterruptedException {
         Assessment assessment = createAssessment(Questionnaire.findAll().firstResult(), 3410L);
 
@@ -244,6 +252,7 @@ public class AssessmentSvcTest {
         return option.selected;
     }
 
+    @Transactional
     private void addStakeholdersToAssessment(Assessment assessment) {
         AssessmentStakeholder stakeholder = AssessmentStakeholder.builder().assessment(assessment).stakeholderId(100L).build();
         stakeholder.persist();
@@ -267,6 +276,7 @@ public class AssessmentSvcTest {
     }
 
     @Test
+    @Transactional
     public void given_SameApplication_when_SeveralAssessmentCreation_should_ThrowException() throws InterruptedException {
         Questionnaire questionnaire = createQuestionnaire();
         CompletableFuture<Assessment> future1 = managedExecutor.supplyAsync(() -> createAssessment(questionnaire, 5L));
@@ -277,17 +287,22 @@ public class AssessmentSvcTest {
     }
 
     @Test
-    public void given_SameApplicationButDeletedTrue_when_SeveralAssessmentCreation_should_NotThrowException() {
+    public void given_SameApplicationButDeletedTrue_when_SeveralAssessmentCreation_should_NotThrowException() throws SystemException, NotSupportedException, HeuristicRollbackException, HeuristicMixedException, RollbackException {
+        transaction.begin();
         Questionnaire questionnaire = createQuestionnaire();
-        Assessment assessment1 = createAssessment(questionnaire, 200L);
+        Assessment assessment1 = createAssessment(questionnaire, 6200L);
         assertThat(assessment1).matches(e -> e.id > 0);
-        assertThatThrownBy(() -> createAssessment(questionnaire, 200L));
+        transaction.commit();
+        assertThatThrownBy(() -> createAssessment(questionnaire, 6200L));
         assessmentSvc.deleteAssessment(assessment1.id);
-        Assessment assessment2 = createAssessment(questionnaire, 200L);
+        transaction.begin();
+        Assessment assessment2 = createAssessment(questionnaire, 6200L);
         assertThat(assessment2).matches(e -> e.id > 0);
+        transaction.commit();
     }
 
     @Test
+    @Transactional
     public void given_CreatedAssessment_When_DeleteAssessment_should_DeleteIt() {
         Questionnaire questionnaire = createQuestionnaire();
         Assessment assessment = createAssessment(questionnaire, 1200L);
@@ -376,6 +391,7 @@ public class AssessmentSvcTest {
         return questionnaire;
     }
 
+    @Transactional
     private Category createCategory(Questionnaire questionnaire, int order) {
         Category category = Category.builder().name("category-" + order).order(order).questionnaire(questionnaire)
                 .build();
@@ -386,6 +402,7 @@ public class AssessmentSvcTest {
         return category;
     }
 
+    @Transactional
     private Question createQuestion(Category category, int i) {
         Question question = Question.builder().name("question-" + i).order(i).questionText("questionText-" + i)
                 .description("tooltip-" + i).type(QuestionType.SINGLE).build();
@@ -397,6 +414,7 @@ public class AssessmentSvcTest {
         return question;
     }
 
+    @Transactional
     private SingleOption createSingleOption(Question question, int i) {
         SingleOption single = SingleOption.builder().option("option-" + i).order(i).question(question)
                 .risk(Risk.values()[new Random().nextInt(Risk.values().length)]).build();

--- a/src/test/java/io/tackle/pathfinder/services/AssessmentSvcTest.java
+++ b/src/test/java/io/tackle/pathfinder/services/AssessmentSvcTest.java
@@ -192,6 +192,9 @@ public class AssessmentSvcTest {
         assertThat(assessmentUpdated.stakeholders).extracting(e -> e.stakeholderId).containsExactlyInAnyOrder(100L, 200L, 300L);
         assertThat(assessmentUpdated.stakeholdergroups).extracting(e -> e.stakeholdergroupId).containsExactlyInAnyOrder(500L, 600L);
         
+        // adding again the same original list to the dtos, should not change anything as we are adding the same ones it contains
+        assessmentDto.setStakeholderGroups(List.of(500L, 600L));
+        assessmentDto.setStakeholders(List.of(100L, 200L, 300L));
         assessmentSvc.updateAssessment(assessment.id, assessmentDto);
         assessmentUpdated = Assessment.findById(assessment.id);
         assertThat(assessmentUpdated.stakeholders).extracting(e -> e.stakeholderId).containsExactlyInAnyOrder(100L, 200L, 300L);


### PR DESCRIPTION
Issue : https://github.com/konveyor/tackle-pathfinder/issues/43


### Features covered
* Avoid Stakeholders and Stakeholdergroups duplicity on updating an assessment

### Unit , Integration and End2End Tests cases covered
* Unit Test ( AssessmentSvcTest.java )
  * given_CreatedAssessment_When_UpdateSeveralTimes_Then_StakeholdersAreNotDuplicated
* End2End Test on minikube with native image ( check_api.sh )
  * 8 Given an assessment, update few values and check return value is 200

### Pre steps Minikube: 
1. Install minikube : https://minikube.sigs.k8s.io/docs/start/
1. Start minikube : minikube start --kubernetes-version=v1.20.2 --cpus 4 --memory 12000
1. Enable ingress addons : minikube addons enable ingress
1. Create tackle namespace
```Shell
kubectl create namespace tackle
``` 
1. Deploy tackle ( to have the keycloak instance running ) on your K8s cluster
```Shell
$ kubectl apply -f  https://raw.githubusercontent.com/konveyor/tackle/main/kubernetes/kubernetes-tackle.yaml -n tackle
```
5. Edit the Ingress object to allow direct request to Pathfinder API
```Shell
$ kubectl edit ingress tackle -n tackle
```
Add this below `paths:`
```Yaml
     - backend:
          service:
            name: tackle-pathfinder
            port:
              number: 8080 
        path: /pathfinder
        pathType: ImplementationSpecific
```
6. Build and push 
```Shell
$ ./mvnw -U -B package -Dquarkus.container-image.push=true -Dquarkus.container-image.group={your quay user} -Dquarkus.container-image.registry=quay.io -Dquarkus.container-image.username={your quay user} -Dquarkus.container-image.password={your quay pwd} -Pnative
```
7. Change the image in the deployment tackle-pathfinder to be the one you have pushed
8. Rollout to update the image
```Shell
$ kubectl rollout restart deployment tackle-pathfinder -n tackle
```

### Test case with Minikube : Do the full API test
```Shell
$ .github/scripts/check_api.sh
```
> Expect 
```Shell
+++++ API CHECK SUCCESSFUL ++++++
```

### Pre steps non containerised local test:
1. run keycloak
```Shell
podman run -it --name keycloak --rm \     
            -e KEYCLOAK_USER=admin -e KEYCLOAK_PASSWORD=admin -e KEYCLOAK_IMPORT=/tmp/keycloak/quarkus-realm.json \
            -e DB_VENDOR=h2 -p 8180:8080 -p 8543:8443 -v ./src/main/resources/keycloak:/tmp/keycloak:Z \
            jboss/keycloak:12.0.2
```
1. run postgresql
```Shell
podman run -it \                          
            --name postgres-pathfinder -e POSTGRES_USER=pathfinder \                                               
            -e POSTGRES_PASSWORD=pathfinder -e POSTGRES_DB=pathfinder_db \                              
            -p 5433:5432 postgres:10.6
```
1. run application
```Shell
./mvnw quarkus:dev
```
 
### Test case with local non containerised : Do the full API test
```Shell
$ .github/scripts/check_api.sh localhost:8085 localhost:8180
```
> Expect 
```Shell
+++++ API CHECK SUCCESSFUL ++++++
```

### NOTE 
Script Test step number involved in this feature : 8

