### PR TITLE
[Tackle-233] landscape error including deleted assessments

### DIFF
--- a/src/main/java/io/tackle/pathfinder/controllers/AssessmentsResource.java
+++ b/src/main/java/io/tackle/pathfinder/controllers/AssessmentsResource.java
@@ -87,6 +87,7 @@ public class AssessmentsResource {
   @POST
   @Path("/assessment-risk")
   @Produces("application/json")
+  @Consumes("application/json")
   public List<LandscapeDto> getLandscape(@NotNull @Valid List<ApplicationDto> applicationIds) {
     if (applicationIds.isEmpty()) throw new BadRequestException();
     return service.landscape(applicationIds.stream().map(e -> e.getApplicationId()).collect(Collectors.toList()));

--- a/src/main/java/io/tackle/pathfinder/services/AssessmentSvc.java
+++ b/src/main/java/io/tackle/pathfinder/services/AssessmentSvc.java
@@ -316,8 +316,8 @@ public class AssessmentSvc {
                 "            trunc(((0.0 + Count(*) OVER w_risk_count) / (Count(*) OVER (PARTITION BY assess.id)) * 100)) AS pct " +
                 "            FROM assessment_singleoption so " +
                 "                    join assessment_question qu on (qu.id = so.assessment_question_id and qu.deleted is not true) " +
-                "                    join assessment_category ca on (ca.id = qu.assessment_category_id and ca..deleted is not true) " +
-                "                    join assessment_questionnaire ques on (ques.id = ca.assessment_questionnaire_id and ques..deleted is not true) " +
+                "                    join assessment_category ca on (ca.id = qu.assessment_category_id and ca.deleted is not true) " +
+                "                    join assessment_questionnaire ques on (ques.id = ca.assessment_questionnaire_id and ques.deleted is not true) " +
                 "                    join assessment assess on (assess.id = ques.assessment_id and assess.deleted is not true) " +
                 "            WHERE so.selected = true " +
                 "                   AND assess.application_id in (" + applicationIds.stream().map(e -> e.toString()).collect(Collectors.joining(",")) + ") " +

--- a/src/main/java/io/tackle/pathfinder/services/AssessmentSvc.java
+++ b/src/main/java/io/tackle/pathfinder/services/AssessmentSvc.java
@@ -29,8 +29,6 @@ import javax.validation.constraints.NotNull;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.NotFoundException;
 
-import java.math.BigDecimal;
-import java.math.BigInteger;
 import java.util.*;
 import java.util.function.Function;
 import java.util.logging.Level;
@@ -317,10 +315,10 @@ public class AssessmentSvc {
                 "            so.risk, " +
                 "            trunc(((0.0 + Count(*) OVER w_risk_count) / (Count(*) OVER (PARTITION BY assess.id)) * 100)) AS pct " +
                 "            FROM assessment_singleoption so " +
-                "                    join assessment_question qu on (qu.id = so.assessment_question_id) " +
-                "                    join assessment_category ca on (ca.id = qu.assessment_category_id) " +
-                "                    join assessment_questionnaire ques on (ques.id = ca.assessment_questionnaire_id) " +
-                "                    join assessment assess on (assess.id = ques.assessment_id) " +
+                "                    join assessment_question qu on (qu.id = so.assessment_question_id and qu.deleted is not true) " +
+                "                    join assessment_category ca on (ca.id = qu.assessment_category_id and ca..deleted is not true) " +
+                "                    join assessment_questionnaire ques on (ques.id = ca.assessment_questionnaire_id and ques..deleted is not true) " +
+                "                    join assessment assess on (assess.id = ques.assessment_id and assess.deleted is not true) " +
                 "            WHERE so.selected = true " +
                 "                   AND assess.application_id in (" + applicationIds.stream().map(e -> e.toString()).collect(Collectors.joining(",")) + ") " +
                 "                   AND assess.status = 'COMPLETE' " +


### PR DESCRIPTION
Issue : Tackle-233

* added filter ".deleted is not true" tothe landscape Query

### Before : 
![image](https://user-images.githubusercontent.com/1836434/121686402-6829c980-cac1-11eb-9ad6-9639f7f2f4a3.png)

### After : 
![image](https://user-images.githubusercontent.com/1836434/121686442-7a0b6c80-cac1-11eb-8259-fb36cbb0297a.png)
