### PR TITLE
Build container image in docker.pkg.github.com and add a comment in the PR

### DIFF
--- a/.github/workflows/pr-build-container-images-comment.yml
+++ b/.github/workflows/pr-build-container-images-comment.yml
@@ -1,0 +1,20 @@
+name: PR build container images comment
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'Thanks for your contribution! \n Every commit will generate a new build at https://github.com/${{github.event.pull_request.head.repo.full_name}}/actions/workflows/pr-build-container-images.yml?query=branch%3A${{github.event.pull_request.head.ref}} and once the build finishes you should be able to use the container image `docker.pkg.github.com/${{github.event.pull_request.head.repo.full_name}}/${{github.event.repository.name}}:${{github.event.pull_request.head.ref}}` \n To see the full set of container images generated visit https://github.com/${{github.event.pull_request.head.repo.full_name}}/packages'
+            })

--- a/.github/workflows/pr-build-container-images.yml
+++ b/.github/workflows/pr-build-container-images.yml
@@ -1,0 +1,31 @@
+name: PR build container images
+
+on: [push]
+
+jobs:
+  container-images:
+    if: ${{ github.event_name != 'pull_request' && github.repository_owner != 'konveyor' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: "11"
+          distribution: "adopt"
+          java-package: jdk
+      - name: Extract branch name
+        shell: bash
+        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+        id: extract_branch
+      - name: Build and Push to GitHub Packages
+        run: |
+          mvn -U -B package --file pom.xml \
+          -Pcontainer-image -Pnative -DskipTests \
+          -Dquarkus.container-image.push=true \
+          -Dquarkus.container-image.group=${{ github.repository_owner }} \
+          -Dquarkus.container-image.name=${{ github.event.repository.name }}/tackle-pathfinder \
+          -Dquarkus.container-image.tag=${{ steps.extract_branch.outputs.branch }} \
+          -Dquarkus.container-image.registry=docker.pkg.github.com \
+          -Dquarkus.container-image.username=${{ github.actor }} \
+          -Dquarkus.container-image.password=${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds a comment for every new PR created into this repository. This will help users know that there is a container image available for them to be used.

Since the workflow to add a comment uses pull_request_target it can only be tested once the workflow is in the main branch.