### PR TITLE
Tackle-244 Add applicationId to the Landscape report

### DIFF
--- a/.github/scripts/check_api.sh
+++ b/.github/scripts/check_api.sh
@@ -233,7 +233,7 @@ landscapeJson=$(curl "http://$api_ip/pathfinder/assessments/assessment-risk" \
             -H "Authorization: Bearer $access_token" -w "%{http_code}" \
             -d "[{\"applicationId\":325100},{\"applicationId\":998899}]" \
             -H 'Content-Type: application/json')
-echo $landscapeJson | grep "[{\"assessmentId\":$assessmentSourceId,\"risk\":\"RED\"}]"
+echo $landscapeJson | grep "[{\"assessmentId\":$assessmentSourceId,\"risk\":\"RED\",\"applicationId\":325100}]"
 
 echo
 echo

--- a/src/main/java/io/tackle/pathfinder/dto/LandscapeDto.java
+++ b/src/main/java/io/tackle/pathfinder/dto/LandscapeDto.java
@@ -7,4 +7,5 @@ import lombok.Value;
 public class LandscapeDto {
     Long assessmentId;
     Risk risk;
+    Long applicationId;
 }

--- a/src/main/java/io/tackle/pathfinder/mapper/AssessmentMapper.java
+++ b/src/main/java/io/tackle/pathfinder/mapper/AssessmentMapper.java
@@ -58,14 +58,14 @@ public abstract class AssessmentMapper {
     @Mapping(target = "stakeholderGroups", source = "stakeholdergroups")
     public abstract AssessmentDto assessmentToAssessmentDto(Assessment assessment, @Context String language);
 
-    private RiskLineDto getRiskLineDto(Tuple fields) {
+    private RiskLineDto getRiskLineDto(Tuple fields, @Context String language) {
         // cat.category_order, cat.name, q.question_order, q.question_text, opt.singleoption_order, opt.option, array_agg(a.application_id)
         String fieldApps = fields.get("applicationIds", String.class);
         String[] appsList = fieldApps.replace("{", "").replace("}", "").split(",");
 
-        BigInteger categoryId = (BigInteger) fields[0];
-        BigInteger questionId = (BigInteger) fields[1];
-        BigInteger optionId = (BigInteger) fields[2];
+        BigInteger categoryId = fields.get("cid", BigInteger.class);
+        BigInteger questionId = fields.get("qid", BigInteger.class);
+        BigInteger optionId = fields.get("soid", BigInteger.class);
 
         Category category = Category.findById(categoryId.longValue());
         Question question = Question.findById(questionId.longValue());
@@ -77,15 +77,15 @@ public abstract class AssessmentMapper {
         List<Long> applications = Arrays.stream(appsList).map(Long::parseLong).collect(Collectors.toList());
 
         return RiskLineDto.builder()
-            .category(fields.get("name", String.class))
-            .question(fields.get("question_text", String.class))
-            .answer(fields.get("option", String.class))
+            .category(categoryText)
+            .question(questionText)
+            .answer(optionText)
             .applications(applications)
             .build();
     }
 
-    public List<RiskLineDto> riskListQueryToRiskLineDtoList(List<Tuple> objectList) {
-        return objectList.stream().map(this::getRiskLineDto).collect(Collectors.toList());
+    public List<RiskLineDto> riskListQueryToRiskLineDtoList(List<Tuple> objectList, @Context String language) {
+        return objectList.stream().map(a -> getRiskLineDto(a, language)).collect(Collectors.toList());
     }
 
     @Transactional

--- a/src/main/java/io/tackle/pathfinder/mapper/AssessmentMapper.java
+++ b/src/main/java/io/tackle/pathfinder/mapper/AssessmentMapper.java
@@ -11,6 +11,7 @@ import org.mapstruct.Context;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import javax.inject.Inject;
+import javax.persistence.Tuple;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -54,20 +55,20 @@ public abstract class AssessmentMapper {
     @Mapping(target = "stakeholderGroups", source = "stakeholdergroups")
     public abstract AssessmentDto assessmentToAssessmentDto(Assessment assessment, @Context String language);
 
-    private RiskLineDto getRiskLineDto(Object[] fields) {
+    private RiskLineDto getRiskLineDto(Tuple fields) {
         // cat.category_order, cat.name, q.question_order, q.question_text, opt.singleoption_order, opt.option, array_agg(a.application_id)
-        String fieldApps = (String) fields[6];
+        String fieldApps = fields.get("applicationIds", String.class);
         String[] appsList = fieldApps.replace("{", "").replace("}", "").split(",");
         List<Long> applications = Arrays.stream(appsList).map(Long::parseLong).collect(Collectors.toList());
         return RiskLineDto.builder()
-            .category((String) fields[1])
-            .question((String) fields[3])
-            .answer((String) fields[5])
+            .category(fields.get("name", String.class))
+            .question(fields.get("question_text", String.class))
+            .answer(fields.get("option", String.class))
             .applications(applications)
             .build();
     }
 
-    public List<RiskLineDto> riskListQueryToRiskLineDtoList(List<Object[]> objectList) {
+    public List<RiskLineDto> riskListQueryToRiskLineDtoList(List<Tuple> objectList) {
         return objectList.stream().map(this::getRiskLineDto).collect(Collectors.toList());
     }
 

--- a/src/main/java/io/tackle/pathfinder/services/AssessmentSvc.java
+++ b/src/main/java/io/tackle/pathfinder/services/AssessmentSvc.java
@@ -378,7 +378,7 @@ public class AssessmentSvc {
         //String sqlString = "select cat.category_order, cat.name, q.question_order, q.question_text, opt.singleoption_order, opt.option, cast(array_agg(a.application_id) as text) \n" +
         String sqlString = " select c.id as cid, q.id as qid, so.id as soid, " +
                            " cat.category_order, que.question_order, opt.singleoption_order, \n" +
-                           " cast(array_agg(a.application_id) as text) \n" +
+                           " cast(array_agg(a.application_id) as text) as applicationIds \n" +
                 " from assessment_category cat join assessment_question que on cat.id = que.assessment_category_id \n" +
                 "                             join assessment_singleoption opt on que.id = opt.assessment_question_id and opt.selected is true \n" +
                 "                             join assessment_questionnaire aq on cat.assessment_questionnaire_id = aq.id \n" +

--- a/src/main/java/io/tackle/pathfinder/services/AssessmentSvc.java
+++ b/src/main/java/io/tackle/pathfinder/services/AssessmentSvc.java
@@ -343,7 +343,7 @@ public class AssessmentSvc {
 
     @Transactional
     public List<LandscapeDto> landscape(List<Long> applicationIds) {
-            String sql = "SELECT cast(ID as int), RISK, cast(trunc(max(PCT)) as int) AS PERCENTAGE , cast(application_id as int) " +
+            String sql = "SELECT ID, RISK, cast(trunc(max(PCT)) as int) AS PERCENTAGE , application_id " +
                 " FROM ( " +
                 "    SELECT assess.id, " +
                 "            so.risk, " +
@@ -460,7 +460,7 @@ public class AssessmentSvc {
     }
 
     private AssessmentRiskDto sqlRowToAssessmentRisk(Tuple row) {
-        return new AssessmentRiskDto(row.get("id", Integer.class), row.get("risk", String.class), row.get("percentage", Integer.class), row.get("application_id", Integer.class));
+        return new AssessmentRiskDto(row.get("id", BigInteger.class).longValue(), row.get("risk", String.class), row.get("percentage", Integer.class), row.get("application_id", BigInteger.class).longValue());
     }
 
     private int compareAssessmentRisk(AssessmentRiskDto o1, AssessmentRiskDto o2) {
@@ -478,9 +478,9 @@ public class AssessmentSvc {
 
     @Value
     public class AssessmentRiskDto {
-        Integer id;
+        Long id;
         String risk;
         Integer percentage;
-        Integer applicationId;
+        Long applicationId;
     }
 }

--- a/src/test/java/io/tackle/pathfinder/controllers/AssessmentsResourceTest.java
+++ b/src/test/java/io/tackle/pathfinder/controllers/AssessmentsResourceTest.java
@@ -821,7 +821,7 @@ public class AssessmentsResourceTest extends SecuredResourceTest {
 			.extract().as(LandscapeDto[].class);
 
 		// assert
-		assertThat(landscape).containsExactlyInAnyOrder(new LandscapeDto(header1.getId(), Risk.GREEN), new LandscapeDto(header2.getId(), Risk.RED));
+		assertThat(landscape).containsExactlyInAnyOrder(new LandscapeDto(header1.getId(), Risk.GREEN, header1.getApplicationId()), new LandscapeDto(header2.getId(), Risk.RED, header2.getApplicationId()));
 	}
 
 	@Test

--- a/src/test/java/io/tackle/pathfinder/services/AssessmentSvcTest.java
+++ b/src/test/java/io/tackle/pathfinder/services/AssessmentSvcTest.java
@@ -416,7 +416,7 @@ public class AssessmentSvcTest {
     @Transactional
     public void given_AssessmentWithNoRedAnswersSeveralAmber_When_landscape_Then_ResultIsAMBER() {
         // create 2 assessments
-        AssessmentHeaderDto assessmentHeader1 = assessmentSvc.createAssessment(894200L);
+        AssessmentHeaderDto assessmentHeader1 = assessmentSvc.createAssessment(Long.MAX_VALUE-1);
         AssessmentHeaderDto assessmentHeader2 = assessmentSvc.createAssessment(893200L);
         Assessment assessment1 =  Assessment.findById(assessmentHeader1.getId());
         Assessment assessment2 =  Assessment.findById(assessmentHeader2.getId());
@@ -428,7 +428,7 @@ public class AssessmentSvcTest {
         assessment2.assessmentQuestionnaire.categories.forEach(e -> e.questions.forEach(f -> f.singleOptions.stream().filter(a -> a.risk == Risk.AMBER).findFirst().ifPresent(b -> b.selected = true)));
 
         // get landscape report of both
-        List<LandscapeDto> landscape = assessmentSvc.landscape(List.of(894200L, 893200L));
+        List<LandscapeDto> landscape = assessmentSvc.landscape(List.of(Long.MAX_VALUE-1, 893200L));
 
         // asserts
         assertThat(landscape).containsExactlyInAnyOrder(new LandscapeDto(assessment1.id, Risk.AMBER, assessment1.applicationId), new LandscapeDto(assessment2.id, Risk.AMBER, assessment2.applicationId));
@@ -565,7 +565,7 @@ public class AssessmentSvcTest {
     @Transactional
     @Test
     public void given_TwoAssessmentsWith6AnswersButSharing2Questions_When_IdentifiedRisks_Then_ResultIs4LinesBut2Has2Applications() {
-        Assessment assessment1 = createAssessment(Questionnaire.findAll().firstResult(), 5566L);
+        Assessment assessment1 = createAssessment(Questionnaire.findAll().firstResult(), Long.MAX_VALUE);
 
         AssessmentQuestion question1 = getAssessmentQuestion(assessment1, 1, 1);
         AssessmentSingleOption option1 = getAssessmentOption(assessment1, 1, Risk.RED, 1);
@@ -587,7 +587,7 @@ public class AssessmentSvcTest {
         AssessmentSingleOption option4 = getAssessmentOption(assessment2, 4, Risk.UNKNOWN,1);
         option4.selected = true;
 
-        List<RiskLineDto> riskLineDtos = assessmentSvc.identifiedRisks(List.of(5566L, 6677L));
+        List<RiskLineDto> riskLineDtos = assessmentSvc.identifiedRisks(List.of(Long.MAX_VALUE, 6677L));
 
         // we have answered 6 options : 3 RED , 1 AMBER, 1 GREEN, 1 UNKNOWN
         // but only the RED answers are returned
@@ -602,7 +602,7 @@ public class AssessmentSvcTest {
                 .filter(e -> e.getQuestion().equals(question1.questionText) && e.getAnswer().equals(option1.option)).count()).isEqualTo(1L);
 
         assertThat(riskLineDtos.stream().filter(e -> e.getQuestion().equals(question1.questionText) && e.getAnswer().equals(option1.option))
-                .findFirst().map(e -> e.getApplications()).get()).containsExactlyInAnyOrder(5566L, 6677L);
+                .findFirst().map(e -> e.getApplications()).get()).containsExactlyInAnyOrder(Long.MAX_VALUE, 6677L);
 
         assertThat(riskLineDtos.stream().filter(e -> e.getQuestion().equals(question3.questionText) && e.getAnswer().equals(option3.option))
                 .findFirst().map(e -> e.getApplications()).get()).containsExactlyInAnyOrder(6677L);

--- a/src/test/java/io/tackle/pathfinder/services/AssessmentSvcTest.java
+++ b/src/test/java/io/tackle/pathfinder/services/AssessmentSvcTest.java
@@ -384,7 +384,7 @@ public class AssessmentSvcTest {
         List<LandscapeDto> landscape = assessmentSvc.landscape(List.of(899200L, 898200L));
 
         // asserts
-        assertThat(landscape).containsExactlyInAnyOrder(new LandscapeDto(assessment1.id, Risk.RED), new LandscapeDto(assessment2.id, Risk.RED));
+        assertThat(landscape).containsExactlyInAnyOrder(new LandscapeDto(assessment1.id, Risk.RED, assessment1.applicationId), new LandscapeDto(assessment2.id, Risk.RED, assessment2.applicationId));
     }
 
     @Test
@@ -409,7 +409,7 @@ public class AssessmentSvcTest {
         List<LandscapeDto> landscape = assessmentSvc.landscape(List.of(896200L, 895200L));
 
         // asserts
-        assertThat(landscape).containsExactlyInAnyOrder(new LandscapeDto(assessment1.id, Risk.GREEN), new LandscapeDto(assessment2.id, Risk.GREEN));
+        assertThat(landscape).containsExactlyInAnyOrder(new LandscapeDto(assessment1.id, Risk.GREEN, assessment1.applicationId), new LandscapeDto(assessment2.id, Risk.GREEN, assessment2.applicationId));
     }
 
     @Test
@@ -431,7 +431,7 @@ public class AssessmentSvcTest {
         List<LandscapeDto> landscape = assessmentSvc.landscape(List.of(894200L, 893200L));
 
         // asserts
-        assertThat(landscape).containsExactlyInAnyOrder(new LandscapeDto(assessment1.id, Risk.AMBER), new LandscapeDto(assessment2.id, Risk.AMBER));
+        assertThat(landscape).containsExactlyInAnyOrder(new LandscapeDto(assessment1.id, Risk.AMBER, assessment1.applicationId), new LandscapeDto(assessment2.id, Risk.AMBER, assessment2.applicationId));
     }
 
     @Test
@@ -452,7 +452,7 @@ public class AssessmentSvcTest {
         List<LandscapeDto> landscape = assessmentSvc.landscape(List.of(1894200L, 1893200L));
 
         // asserts
-        assertThat(landscape).containsExactly(new LandscapeDto(assessment1.id, Risk.AMBER));
+        assertThat(landscape).containsExactly(new LandscapeDto(assessment1.id, Risk.AMBER, assessment1.applicationId));
     }
 
 


### PR DESCRIPTION
Issue : https://github.com/konveyor/tackle-pathfinder/issues/89

In order to test : 

1. clone the code and cd into it
2. execute a pathfinder_db and keycloak

```
podman run -ti --name keycloak --rm \
            -e KEYCLOAK_USER=admin -e KEYCLOAK_PASSWORD=admin -e KEYCLOAK_IMPORT=/tmp/keycloak/quarkus-realm.json \
            -e DB_VENDOR=h2 -p 8180:8080 -p 8543:8443 -v ./src/main/resources/keycloak:/tmp/keycloak:Z \
            jboss/keycloak:12.0.2
```
```
podman run -it \                                 
            --name postgres-pathfinder -e POSTGRES_USER=pathfinder \
            -e POSTGRES_PASSWORD=pathfinder -e POSTGRES_DB=pathfinder_db \
            -p 5433:5432 postgres:10.6
```
3. execute the application in dev mode ` mvn quarkus:dev `
4. there's a convenient SQL script ( db/test-data/V0.0.4_001.1__insert_translations.sql ) that can be executed in the DB
```
podman exec -it postgres-pathfinder /usr/bin/psql pathfinder_db -U pathfinder -c "$(cat src/main/resources/db/test-data/V0.0.4_001.1__insert_translations.sql)"

```
5. execute the check_api.sh
```
.github/scripts/check_api.sh localhost:8085 localhost:8180
```
6.  obtain the token
```
export access_token=$(curl -X POST "http://localhost:8180/auth/realms/quarkus/protocol/openid-connect/token" \
            --user backend-service:secret \
            -H 'content-type: application/x-www-form-urlencoded' \
            -d 'username=alice&password=alice&grant_type=password' | jq --raw-output '.access_token')
```

7. obtain landscape report and check field applicationId is included
```
curl "http://localhost:8085/pathfinder/assessments/assessment-risk" \
            -H 'Accept: application/json' \
            -H "Authorization: Bearer $access_token" -w "%{http_code}" \
            -d "[{\"applicationId\":325100},{\"applicationId\":998899}]" \
            -H 'Content-Type: application/json'
```
