### PR TITLE
Tackle-301 Multi Questionnaire

### DIFF
--- a/src/main/java/io/tackle/pathfinder/controllers/AssessmentsResource.java
+++ b/src/main/java/io/tackle/pathfinder/controllers/AssessmentsResource.java
@@ -1,6 +1,5 @@
 package io.tackle.pathfinder.controllers;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import io.tackle.pathfinder.dto.*;
 import io.tackle.pathfinder.services.AssessmentSvc;
 import io.tackle.pathfinder.services.TranslatorSvc;
@@ -38,13 +37,13 @@ public class AssessmentsResource {
   @POST
   @Produces("application/json")
   @Consumes("application/json")
-  public Response createAssessment(@QueryParam("fromAssessmentId") Long fromAssessmentId, @NotNull @Valid ApplicationDto data) {
+  public Response createAssessment(@QueryParam("fromAssessmentId") Long fromAssessmentId, @NotNull @Valid ApplicationDto data, @QueryParam("questionnaireId") Long questionnaireId) {
     AssessmentHeaderDto createAssessment;
     
     if (fromAssessmentId != null) {
       createAssessment = assessmentSvc.copyAssessment(fromAssessmentId, data.getApplicationId());
     } else {
-      createAssessment = assessmentSvc.createAssessment(data.getApplicationId());
+      createAssessment = assessmentSvc.createAssessment(data.getApplicationId(), questionnaireId);
     }
     
     return Response

--- a/src/main/java/io/tackle/pathfinder/controllers/QuestionnairesResource.java
+++ b/src/main/java/io/tackle/pathfinder/controllers/QuestionnairesResource.java
@@ -1,0 +1,36 @@
+package io.tackle.pathfinder.controllers;
+
+import io.tackle.pathfinder.dto.AssessmentHeaderDto;
+import io.tackle.pathfinder.dto.questionnaire.QuestionnaireHeaderDto;
+import io.tackle.pathfinder.services.AssessmentSvc;
+import io.tackle.pathfinder.services.QuestionnaireSvc;
+import io.tackle.pathfinder.services.TranslatorSvc;
+import org.eclipse.microprofile.jwt.JsonWebToken;
+
+import javax.inject.Inject;
+import javax.validation.constraints.NotNull;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Path("/questionnaires")
+public class QuestionnairesResource {
+    @Inject
+    QuestionnaireSvc questionnaireSvc;
+
+    @Inject
+    TranslatorSvc translatorSvc;
+
+    @Inject
+    JsonWebToken accessToken;
+
+    @GET
+    @Produces("application/json")
+    public List<QuestionnaireHeaderDto> getQuestionnaires(@QueryParam("language") String language) {
+        String lang = translatorSvc.getLanguage(accessToken.getRawToken(), language);
+        return questionnaireSvc.getQuestionnaireHeaderList(lang);
+    }
+}

--- a/src/main/java/io/tackle/pathfinder/dto/questionnaire/QuestionnaireHeaderDto.java
+++ b/src/main/java/io/tackle/pathfinder/dto/questionnaire/QuestionnaireHeaderDto.java
@@ -1,0 +1,40 @@
+package io.tackle.pathfinder.dto.questionnaire;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+import io.tackle.pathfinder.dto.AssessmentStatus;
+import io.tackle.pathfinder.dto.BasicDto;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+
+/**
+ * 
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "id",
+    "name",
+    "language"
+})
+@Data
+@SuperBuilder
+@AllArgsConstructor
+@NoArgsConstructor
+@RegisterForReflection
+public class QuestionnaireHeaderDto extends BasicDto {
+    @JsonProperty("name")
+    @JsonPropertyDescription("")
+    private String name;
+
+
+    @JsonProperty("language")
+    @JsonPropertyDescription("")
+    private String language;
+}

--- a/src/main/java/io/tackle/pathfinder/mapper/AssessmentMapper.java
+++ b/src/main/java/io/tackle/pathfinder/mapper/AssessmentMapper.java
@@ -20,9 +20,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Mapper(componentModel = "cdi")
-public abstract class AssessmentMapper {
-    @Inject
-    TranslatorSvc translatorSvc;
+public abstract class AssessmentMapper extends TranslatorMapper{
 
     public abstract AssessmentHeaderDto assessmentToAssessmentHeaderDto(Assessment assessment);
 
@@ -43,7 +41,7 @@ public abstract class AssessmentMapper {
     public abstract List<AssessmentCategoryDto> assessmentCategoryListToAssessmentCategoryDtoList(List<AssessmentCategory> categoryList, @Context String language);
 
     @Mapping(target="title", source="name")
-    @Mapping(target = "language", expression="java(language)")
+    @Mapping(target = "language", expression="java(org.apache.commons.lang3.StringUtils.defaultString(language, questionnaire.languageCode))")
     public abstract AssessmentQuestionnaireDto assessmentQuestionnaireToAssessmentQuestionnaireDto(AssessmentQuestionnaire questionnaire, @Context String language);
 
     public List<Long> assessmentStakeholderListToLongList(List<AssessmentStakeholder> stakeholder) {
@@ -110,12 +108,4 @@ public abstract class AssessmentMapper {
             .map(a -> translate((PanacheEntity) a, defaultText, destLanguage, field))
             .orElse(defaultText);
     }
-
-    protected String translate(PanacheEntity dto, String defaultText, String destLanguage, String field) {
-        if (StringUtils.isBlank(destLanguage)) return defaultText;
-
-        String key = translatorSvc.getKey(dto, field);
-        return translatorSvc.translate(key, destLanguage, defaultText);
-    }
-
 }

--- a/src/main/java/io/tackle/pathfinder/mapper/QuestionnaireMapper.java
+++ b/src/main/java/io/tackle/pathfinder/mapper/QuestionnaireMapper.java
@@ -1,0 +1,14 @@
+package io.tackle.pathfinder.mapper;
+
+import io.tackle.pathfinder.dto.questionnaire.QuestionnaireHeaderDto;
+import io.tackle.pathfinder.model.questionnaire.Questionnaire;
+import org.mapstruct.Context;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "cdi")
+public abstract class QuestionnaireMapper extends TranslatorMapper {
+    @Mapping(target = "language", expression="java(org.apache.commons.lang3.StringUtils.defaultString(language, questionnaire.languageCode))")
+    @Mapping(target = "name", expression="java(translate(\"Questionnaire\", questionnaire.id, questionnaire.name, language, \"name\"))")
+    public abstract QuestionnaireHeaderDto questionnaireToQuestionnaireHeaderDto(Questionnaire questionnaire, @Context String language);
+}

--- a/src/main/java/io/tackle/pathfinder/mapper/TranslatorMapper.java
+++ b/src/main/java/io/tackle/pathfinder/mapper/TranslatorMapper.java
@@ -1,0 +1,26 @@
+package io.tackle.pathfinder.mapper;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+import io.tackle.pathfinder.services.TranslatorSvc;
+import org.apache.commons.lang3.StringUtils;
+
+import javax.inject.Inject;
+
+public abstract class TranslatorMapper {
+    @Inject
+    TranslatorSvc translatorSvc;
+
+    protected String translate(PanacheEntity dto, String defaultText, String destLanguage, String field) {
+        if (StringUtils.isBlank(destLanguage)) return defaultText;
+
+        String key = translatorSvc.getKey(dto, field);
+        return translatorSvc.translate(key, destLanguage, defaultText);
+    }
+
+    protected String translate(String table, Long id, String defaultText, String destLanguage, String field) {
+        if (StringUtils.isBlank(destLanguage)) return defaultText;
+
+        String key = translatorSvc.getKey(table, id, field);
+        return translatorSvc.translate(key, destLanguage, defaultText);
+    }
+}

--- a/src/main/java/io/tackle/pathfinder/services/AssessmentSvc.java
+++ b/src/main/java/io/tackle/pathfinder/services/AssessmentSvc.java
@@ -78,6 +78,11 @@ public class AssessmentSvc {
 
     @Transactional
     public AssessmentHeaderDto createAssessment(@NotNull Long applicationId) {
+        return createAssessment(applicationId, null);
+    }
+
+    @Transactional
+    public AssessmentHeaderDto createAssessment(@NotNull Long applicationId, Long questionnaireId) {
         long count = Assessment.count("application_id", applicationId);
         log.log(Level.FINE, "Assessments for application_id [ " + applicationId + "] : " + count);
         if (count == 0) {
@@ -86,7 +91,10 @@ public class AssessmentSvc {
             assessment.status = AssessmentStatus.STARTED;
             assessment.persistAndFlush();
 
-            copyQuestionnaireIntoAssessment(assessment, defaultQuestionnaire());
+            Questionnaire questionnaire = (Questionnaire) Optional.ofNullable(questionnaireId)
+                .map(Questionnaire::findById)
+                .orElse(defaultQuestionnaire());
+            copyQuestionnaireIntoAssessment(assessment,  questionnaire);
 
             return assessmentMapper.assessmentToAssessmentHeaderDto(assessment);
         } else {

--- a/src/main/java/io/tackle/pathfinder/services/AssessmentSvc.java
+++ b/src/main/java/io/tackle/pathfinder/services/AssessmentSvc.java
@@ -91,9 +91,7 @@ public class AssessmentSvc {
             assessment.status = AssessmentStatus.STARTED;
             assessment.persistAndFlush();
 
-            Questionnaire questionnaire = (Questionnaire) Optional.ofNullable(questionnaireId)
-                .map(Questionnaire::findById)
-                .orElse(defaultQuestionnaire());
+            Questionnaire questionnaire = questionnaireId != null ? Questionnaire.findById(questionnaireId) : defaultQuestionnaire();
             copyQuestionnaireIntoAssessment(assessment,  questionnaire);
 
             return assessmentMapper.assessmentToAssessmentHeaderDto(assessment);

--- a/src/main/java/io/tackle/pathfinder/services/QuestionnaireSvc.java
+++ b/src/main/java/io/tackle/pathfinder/services/QuestionnaireSvc.java
@@ -1,0 +1,22 @@
+package io.tackle.pathfinder.services;
+
+import io.tackle.pathfinder.dto.questionnaire.QuestionnaireHeaderDto;
+import io.tackle.pathfinder.mapper.QuestionnaireMapper;
+import io.tackle.pathfinder.model.questionnaire.Questionnaire;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@ApplicationScoped
+public class QuestionnaireSvc {
+    @Inject
+    QuestionnaireMapper questionnaireMapper;
+
+    public List<QuestionnaireHeaderDto> getQuestionnaireHeaderList(String lang) {
+        return Questionnaire.listAll().stream()
+            .map(a -> questionnaireMapper.questionnaireToQuestionnaireHeaderDto((Questionnaire) a, lang))
+            .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/io/tackle/pathfinder/services/TranslatorSvc.java
+++ b/src/main/java/io/tackle/pathfinder/services/TranslatorSvc.java
@@ -18,7 +18,11 @@ import java.util.Base64;
 public class TranslatorSvc {
 
     public String getKey(PanacheEntity b, String concept) {
-        return String.format("%s_%s_%s", b.getClass().getSimpleName(), b.id, concept);
+        return getKey(b.getClass().getSimpleName(), b.id, concept);
+    }
+
+    public String getKey(String table, Long id, String field) {
+        return String.format("%s_%s_%s", table, id, field);
     }
 
     @Transactional

--- a/src/main/resources/META-INF/openapi.json
+++ b/src/main/resources/META-INF/openapi.json
@@ -3,7 +3,7 @@
     "info": {
         "title": "tackle-pathfinder",
         "version": "0.0.4",
-        "description": "Tackle PathFinder 0.0.4\n\nChanges : \n* added delete assessment function\n* added create assessment copying responses from another assessment\n* added bulk creation/copy of assessments\n* added identified risks function\n* added assessment confidence function\n* added multilanguage optional param for GetAssessment"
+        "description": "Tackle PathFinder 0.0.4\n\nChanges : \n* added delete assessment function\n* added create assessment copying responses from another assessment\n* added bulk creation/copy of assessments\n* added identified risks function\n* added assessment confidence function\n* added multilanguage optional param for GetAssessment\n* added get questionnaire header list\n"
     },
     "paths": {
         "/assessments": {
@@ -755,6 +755,51 @@
                             }
                         },
                         "description": "Success response"
+                    }
+                }
+            }
+        },
+        "/questionnaires": {
+            "get": {
+                "parameters": [
+                    {
+                        "name": "language",
+                        "description": "",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/QuestionnaireHeader"
+                                    }
+                                },
+                                "examples": {
+                                    "success_questionnaireheader": {
+                                        "value": [
+                                            {
+                                                "id": 9,
+                                                "name": "some text",
+                                                "language": "some text"
+                                            },
+                                            {
+                                                "id": 84,
+                                                "name": "some text",
+                                                "language": "some text"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        },
+                        "description": "Success"
                     }
                 }
             }
@@ -1554,6 +1599,29 @@
                     "risk": {
                         "$ref": "#/components/schemas/Risk",
                         "description": ""
+                    }
+                }
+            },
+            "QuestionnaireHeader": {
+                "description": "",
+                "required": [
+                    "id",
+                    "name",
+                    "language"
+                ],
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "description": "",
+                        "type": "integer"
+                    },
+                    "name": {
+                        "description": "",
+                        "type": "string"
+                    },
+                    "language": {
+                        "description": "",
+                        "type": "string"
                     }
                 }
             }

--- a/src/test/java/io/tackle/pathfinder/controllers/QuestionnairesResourceTest.java
+++ b/src/test/java/io/tackle/pathfinder/controllers/QuestionnairesResourceTest.java
@@ -36,7 +36,7 @@ public class QuestionnairesResourceTest extends SecuredResourceTest {
             .extract().as(QuestionnaireHeaderDto[].class);
 
         assertThat(questionnaires)
-            .hasSize(1)
+            .hasSizeGreaterThan(0)
             .usingRecursiveComparison()
             .ignoringFields("id")
             .isEqualTo(QuestionnaireHeaderDto.builder()
@@ -48,11 +48,11 @@ public class QuestionnairesResourceTest extends SecuredResourceTest {
     @Test
     public void given_Questionnaire_When_GetInADifferentLanguage_Then_ReturnsHeaderDtoInThatLanguage() throws SystemException, NotSupportedException, HeuristicRollbackException, HeuristicMixedException, RollbackException {
         userTransaction.begin();
-        translatorSvc.addOrUpdateTranslation(Questionnaire.findAll().firstResult(), "name", "CAT Pathfinder", "CA");
+        translatorSvc.addOrUpdateTranslation(Questionnaire.findAll().firstResult(), "name", "CA Pathfinder", "CA");
         userTransaction.commit();
 
         QuestionnaireHeaderDto[] questionnaires = given()
-            .queryParam("language", "CAT")
+            .queryParam("language", "CA")
             .when()
             .get("/questionnaires")
             .then()
@@ -60,12 +60,12 @@ public class QuestionnairesResourceTest extends SecuredResourceTest {
             .extract().as(QuestionnaireHeaderDto[].class);
 
         assertThat(questionnaires)
-            .hasSize(1)
+            .hasSizeGreaterThan(0)
             .usingRecursiveComparison()
             .ignoringFields("id")
             .isEqualTo(QuestionnaireHeaderDto.builder()
-                .name("CAT Pathfinder")
-                .language("CAT")
+                .name("CA Pathfinder")
+                .language("CA")
                 .build());
     }
 }

--- a/src/test/java/io/tackle/pathfinder/controllers/QuestionnairesResourceTest.java
+++ b/src/test/java/io/tackle/pathfinder/controllers/QuestionnairesResourceTest.java
@@ -1,0 +1,71 @@
+package io.tackle.pathfinder.controllers;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.tackle.commons.tests.SecuredResourceTest;
+import io.tackle.pathfinder.dto.AssessmentHeaderDto;
+import io.tackle.pathfinder.dto.AssessmentStatus;
+import io.tackle.pathfinder.dto.questionnaire.QuestionnaireHeaderDto;
+import io.tackle.pathfinder.model.questionnaire.Questionnaire;
+import io.tackle.pathfinder.services.QuestionnaireSvc;
+import io.tackle.pathfinder.services.TranslatorSvc;
+import org.junit.jupiter.api.Test;
+
+import javax.inject.Inject;
+import javax.transaction.*;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@QuarkusTest
+public class QuestionnairesResourceTest extends SecuredResourceTest {
+    @Inject
+    TranslatorSvc translatorSvc;
+
+    @Inject
+    UserTransaction userTransaction;
+
+    @Test
+    public void given_Questionnaire_When_Get_Then_ReturnsHeaderDto() {
+        QuestionnaireHeaderDto[] questionnaires = given()
+            .queryParam("language", "EN")
+            .when()
+            .get("/questionnaires")
+            .then()
+            .statusCode(200)
+            .extract().as(QuestionnaireHeaderDto[].class);
+
+        assertThat(questionnaires)
+            .hasSize(1)
+            .usingRecursiveComparison()
+            .ignoringFields("id")
+            .isEqualTo(QuestionnaireHeaderDto.builder()
+                .name("Pathfinder")
+                .language("EN")
+                .build());
+    }
+
+    @Test
+    public void given_Questionnaire_When_GetInADifferentLanguage_Then_ReturnsHeaderDtoInThatLanguage() throws SystemException, NotSupportedException, HeuristicRollbackException, HeuristicMixedException, RollbackException {
+        userTransaction.begin();
+        translatorSvc.addOrUpdateTranslation(Questionnaire.findAll().firstResult(), "name", "CAT Pathfinder", "CA");
+        userTransaction.commit();
+
+        QuestionnaireHeaderDto[] questionnaires = given()
+            .queryParam("language", "CAT")
+            .when()
+            .get("/questionnaires")
+            .then()
+            .statusCode(200)
+            .extract().as(QuestionnaireHeaderDto[].class);
+
+        assertThat(questionnaires)
+            .hasSize(1)
+            .usingRecursiveComparison()
+            .ignoringFields("id")
+            .isEqualTo(QuestionnaireHeaderDto.builder()
+                .name("CAT Pathfinder")
+                .language("CAT")
+                .build());
+    }
+}

--- a/src/test/java/io/tackle/pathfinder/services/AssessmentSvcTest.java
+++ b/src/test/java/io/tackle/pathfinder/services/AssessmentSvcTest.java
@@ -502,7 +502,12 @@ public class AssessmentSvcTest {
 
     @Transactional
     public Questionnaire createQuestionnaire() {
-        Questionnaire questionnaire = Questionnaire.builder().name("Test").languageCode("EN").build();
+        return createQuestionnaire("test");
+    }
+
+    @Transactional
+    public Questionnaire createQuestionnaire(String title) {
+        Questionnaire questionnaire = Questionnaire.builder().name(title).languageCode("EN").build();
         questionnaire.persistAndFlush();
 
         questionnaire.categories = IntStream.range(1, 10).mapToObj(e -> createCategory(questionnaire, e)).collect(Collectors.toList());
@@ -517,7 +522,7 @@ public class AssessmentSvcTest {
             .order(order)
             .questionnaire(questionnaire)
             .build();
-        category.persistAndFlush();
+        category.persist();
 
         category.questions = IntStream.range(1, 20).mapToObj(e -> createQuestion(category, e))
                 .collect(Collectors.toList());
@@ -534,7 +539,7 @@ public class AssessmentSvcTest {
             .type(QuestionType.SINGLE)
             .category(category)
             .build();
-        question.persistAndFlush();
+        question.persist();
 
         question.singleOptions = IntStream.range(1, new Random().nextInt(10) + 3)
                 .mapToObj(e -> createSingleOption(question, e)).collect(Collectors.toList());
@@ -550,7 +555,7 @@ public class AssessmentSvcTest {
             .question(question)
             .risk(Risk.values()[new Random().nextInt(Risk.values().length)])
             .build();
-        single.persistAndFlush();
+        single.persist();
         return single;
     }
 
@@ -692,5 +697,19 @@ public class AssessmentSvcTest {
     private AssessmentSingleOption getAssessmentOption(Assessment assessment1, Integer questionOrder , Risk risk, int catOrder) {
         return getAssessmentQuestion(assessment1, questionOrder, catOrder)
                 .singleOptions.stream().filter(e -> e.risk == risk).findFirst().get();
+    }
+
+    @Test
+    @Transactional
+    public void given_SeveralQuestionnaires_when_CreateNewAssessment_then_SuccessAndQuestionnaireSelectedOrDefault() {
+        Questionnaire questionnaire = createQuestionnaire("Second Test");
+
+        AssessmentHeaderDto assessment = assessmentSvc.createAssessment(795566L, questionnaire.id);
+        AssessmentDto assessmentDto = assessmentSvc.getAssessmentDtoByAssessmentId(assessment.getId(), "EN");
+        assertThat(assessmentDto.getQuestionnaire().getTitle()).isEqualTo("Second Test");
+
+        AssessmentHeaderDto assessment2 = assessmentSvc.createAssessment(895566L);
+        AssessmentDto assessmentDto2 = assessmentSvc.getAssessmentDtoByAssessmentId(assessment2.getId(), "EN");
+        assertThat(assessmentDto2.getQuestionnaire().getTitle()).isEqualTo("Pathfinder");
     }
 }

--- a/src/test/java/io/tackle/pathfinder/services/QuestionnaireSvcTest.java
+++ b/src/test/java/io/tackle/pathfinder/services/QuestionnaireSvcTest.java
@@ -1,0 +1,42 @@
+package io.tackle.pathfinder.services;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.tackle.pathfinder.dto.questionnaire.QuestionnaireHeaderDto;
+import io.tackle.pathfinder.model.questionnaire.Questionnaire;
+import org.assertj.core.groups.Tuple;
+import org.junit.jupiter.api.Test;
+
+import javax.inject.Inject;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@QuarkusTest
+class QuestionnaireSvcTest {
+    @Inject
+    QuestionnaireSvc questionnaireSvc;
+
+    @Inject
+    TranslatorSvc translatorSvc;
+
+    @Test
+    public void given_FewQuestionnaires_when_GetQuestionnaires_then_ListOfQuestionnaireHeaderIsReturned() {
+        List<QuestionnaireHeaderDto> questionnaireHeaderList = questionnaireSvc.getQuestionnaireHeaderList(null);
+        assertThat(questionnaireHeaderList).size().isGreaterThan(0);
+        assertThat(questionnaireHeaderList)
+            .extracting("name", "language")
+            .contains(Tuple.tuple("Pathfinder", "EN"));
+    }
+
+    @Test
+    public void given_FewQuestionnaires_when_GetQuestionnairesWithALanguage_then_ListOfQuestionnaireHeaderIsReturnedInThatLanguage() {
+        translatorSvc.addOrUpdateTranslation(Questionnaire.findAll().firstResult(), "name", "CAT Pathfinder", "CA");
+        List<QuestionnaireHeaderDto> questionnaireHeaderList = questionnaireSvc.getQuestionnaireHeaderList("CA");
+        assertThat(questionnaireHeaderList).size().isGreaterThan(0);
+        assertThat(questionnaireHeaderList)
+            .extracting("name", "language")
+            .contains(Tuple.tuple("CAT Pathfinder", "CA"));
+    }
+}


### PR DESCRIPTION
Issue : https://github.com/konveyor/tackle-pathfinder/issues/98

* New endpoint /questionnaires , accepting queryparam "language" , will return a list of { id, name, language }

* New optional queryparam for the createAssessment /assessments endpoint "questionnaireId" to specify the questionnaire to create an assessment

Test case
* start keycloak and postgre containers
* start app on dev mode 
* connect to the DB with psql and execute the file, chaning the name of the questionnaire, and some categories : src/main/resources/db/migration/V0.0.2_003__insert_default_questionnaire.sql
* execute curl to get the keycloak token
* execute curl to get the questionnaires Ids
```
curl -X GET "http:/localhost:8085/pathfinder/questionnaires" -H 'Accept: application/json' \
            -H "Authorization: Bearer $access_token" -s
```
* execute curl to create the assessment using the id of the new questionnaire
* execute curl to get the new assessment and check the contents
( check the `check_api.sh` script to see the curl commands )