### PR TITLE
[TACKLE-419]-Allow Pathfinder to run without Keycloak

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,6 +164,10 @@
       <artifactId>quarkus-keycloak-authorization</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-security</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.jacoco</groupId>
       <artifactId>org.jacoco.agent</artifactId>
       <classifier>runtime</classifier>

--- a/src/main/java/io/tackle/pathfinder/model/Constants.java
+++ b/src/main/java/io/tackle/pathfinder/model/Constants.java
@@ -1,0 +1,5 @@
+package io.tackle.pathfinder.model;
+
+public interface Constants {
+    String defaultLanguage = "EN";
+}

--- a/src/main/java/io/tackle/pathfinder/model/assessment/AssessmentQuestionnaire.java
+++ b/src/main/java/io/tackle/pathfinder/model/assessment/AssessmentQuestionnaire.java
@@ -1,6 +1,7 @@
 package io.tackle.pathfinder.model.assessment;
 
 import io.quarkus.hibernate.orm.panache.PanacheEntity;
+import io.tackle.pathfinder.model.Constants;
 import io.tackle.pathfinder.model.questionnaire.Questionnaire;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -49,7 +50,7 @@ public class AssessmentQuestionnaire extends PanacheEntity {
     
     @Column(name="language_code", nullable = false)
     @Builder.Default
-    public String languageCode = "EN";
+    public String languageCode = Constants.defaultLanguage;
 
     @Basic(optional = false)
     public String name;

--- a/src/main/java/io/tackle/pathfinder/model/questionnaire/Questionnaire.java
+++ b/src/main/java/io/tackle/pathfinder/model/questionnaire/Questionnaire.java
@@ -1,6 +1,7 @@
  package io.tackle.pathfinder.model.questionnaire;
 
 import io.tackle.commons.entities.AbstractEntity;
+import io.tackle.pathfinder.model.Constants;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
@@ -26,7 +27,7 @@ import java.util.List;
 public class Questionnaire extends AbstractEntity {
     @Column(name="language_code", nullable = false)
     @Builder.Default
-    public String languageCode = "EN";
+    public String languageCode = Constants.defaultLanguage;
 
     @Basic(optional = false)
     public String name;

--- a/src/main/java/io/tackle/pathfinder/security/DisabledAuthController.java
+++ b/src/main/java/io/tackle/pathfinder/security/DisabledAuthController.java
@@ -1,0 +1,24 @@
+package io.tackle.pathfinder.security;
+
+import io.quarkus.security.spi.runtime.AuthorizationController;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import javax.annotation.Priority;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Alternative;
+import javax.interceptor.Interceptor;
+
+@Alternative
+@Priority(Interceptor.Priority.LIBRARY_AFTER)
+@ApplicationScoped
+public class DisabledAuthController extends AuthorizationController {
+
+    @ConfigProperty(name = "pathfinder.disable.authorization", defaultValue = "false")
+    boolean disableAuthorization;
+
+    @Override
+    public boolean isAuthorizationEnabled() {
+        return !disableAuthorization;
+    }
+
+}

--- a/src/main/java/io/tackle/pathfinder/services/TranslatorSvc.java
+++ b/src/main/java/io/tackle/pathfinder/services/TranslatorSvc.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.quarkus.hibernate.orm.panache.PanacheEntity;
+import io.tackle.pathfinder.model.Constants;
 import io.tackle.pathfinder.model.i18n.TranslatedText;
 import lombok.extern.java.Log;
 import org.apache.commons.lang3.StringUtils;
@@ -57,6 +58,7 @@ public class TranslatorSvc {
 
     public String getLanguage(String token, String queryLanguage) {
         if (StringUtils.isNotBlank(queryLanguage)) return queryLanguage;
+        if (token == null || token.isEmpty()) return Constants.defaultLanguage;
 
         String tokenBodyJson = new String(Base64.getDecoder().decode(token.split("\\.")[1]));
         return getLocaleFromTokenBody(tokenBodyJson);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -28,6 +28,13 @@ quarkus.hibernate-orm.log.bind-parameters=true
 quarkus.micrometer.export.json.enabled=true
 
 # OIDC Configuration
+quarkus.oidc.enabled=true
+
+quarkus.oidc.tenant-enabled=true
+pathfinder.disable.authorization=false
+%noauth.quarkus.oidc.tenant-enabled=false
+%noauth.pathfinder.disable.authorization=true
+
 quarkus.oidc.auth-server-url=http://keycloak:8080/auth/realms/quarkus
 quarkus.oidc.client-id=backend-service
 quarkus.oidc.credentials.secret=secret

--- a/src/test/java/io/tackle/pathfinder/AbstractResourceTest.java
+++ b/src/test/java/io/tackle/pathfinder/AbstractResourceTest.java
@@ -1,0 +1,56 @@
+package io.tackle.pathfinder;
+
+import io.restassured.RestAssured;
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.RestAssured.oauth2;
+
+public abstract class AbstractResourceTest {
+
+    protected static String PATH = "";
+    protected static String ACCESS_TOKEN;
+
+    @BeforeAll
+    public static void setUp() {
+        Config config = ConfigProvider.getConfig();
+        Boolean oidcEnabled = config.getValue("quarkus.oidc.enabled", Boolean.class);
+        if (oidcEnabled) {
+            final String KEYCLOAK_SERVER_URL = ConfigProvider.getConfig().getOptionalValue("quarkus.oidc.auth-server-url", String.class).orElse("http://localhost:8180/auth");
+            ACCESS_TOKEN = given()
+                    .relaxedHTTPSValidation()
+                    .auth().preemptive().basic("backend-service", "secret")
+                    .contentType("application/x-www-form-urlencoded")
+                    .formParam("grant_type", "password")
+                    .formParam("username", "alice")
+                    .formParam("password", "alice")
+                    .when()
+                    .post(KEYCLOAK_SERVER_URL + "/protocol/openid-connect/token")
+                    .then().extract().path("access_token").toString();
+            RestAssured.authentication = oauth2(ACCESS_TOKEN);
+        }
+    }
+
+    /**
+     * Maybe too much to execute it every time a class extends this one but, right now,
+     * the "better safe than sorry" approach with security is the winning one.
+     */
+    @Test
+    public void testUnauthorized() {
+        Config config = ConfigProvider.getConfig();
+        Boolean authorizationDisabled = config.getValue("pathfinder.disable.authorization", Boolean.class);
+
+        if (!authorizationDisabled) {
+            given().auth().oauth2("")
+                    .accept("application/hal+json")
+                    .queryParam("sort", "id")
+                    .when().get(PATH)
+                    .then()
+                    .statusCode(401);
+        }
+    }
+
+}

--- a/src/test/java/io/tackle/pathfinder/DefaultTestProfile.java
+++ b/src/test/java/io/tackle/pathfinder/DefaultTestProfile.java
@@ -1,0 +1,22 @@
+package io.tackle.pathfinder;
+
+import io.tackle.commons.testcontainers.KeycloakTestResource;
+
+import java.util.List;
+
+import static java.util.Map.entry;
+import static java.util.Map.ofEntries;
+
+public class DefaultTestProfile extends PathfinderTestProfile {
+
+    protected TestResourceEntry kcResource = new TestResourceEntry(KeycloakTestResource.class, ofEntries(
+            entry(KeycloakTestResource.IMPORT_REALM_JSON_PATH, "keycloak/quarkus-realm.json"),
+            entry(KeycloakTestResource.REALM_NAME, "quarkus")
+    ));
+
+    @Override
+    public List<TestResourceEntry> testResources() {
+        return List.of(dbResource, kcResource);
+    }
+
+}

--- a/src/test/java/io/tackle/pathfinder/NoAuthTestProfile.java
+++ b/src/test/java/io/tackle/pathfinder/NoAuthTestProfile.java
@@ -1,0 +1,10 @@
+package io.tackle.pathfinder;
+
+public class NoAuthTestProfile extends PathfinderTestProfile {
+
+    @Override
+    public String getConfigProfile() {
+        return "test,noauth";
+    }
+
+}

--- a/src/test/java/io/tackle/pathfinder/PathfinderTestProfile.java
+++ b/src/test/java/io/tackle/pathfinder/PathfinderTestProfile.java
@@ -1,0 +1,31 @@
+package io.tackle.pathfinder;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.tackle.commons.testcontainers.KeycloakTestResource;
+import io.tackle.commons.testcontainers.PostgreSQLDatabaseTestResource;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static java.util.Map.entry;
+import static java.util.Map.ofEntries;
+
+public abstract class PathfinderTestProfile implements QuarkusTestProfile {
+
+    protected TestResourceEntry dbResource = new TestResourceEntry(PostgreSQLDatabaseTestResource.class, ofEntries(
+            entry(PostgreSQLDatabaseTestResource.DB_NAME, "pathfinder_db"),
+            entry(PostgreSQLDatabaseTestResource.USER, "pathfinder"),
+            entry(PostgreSQLDatabaseTestResource.PASSWORD, "pathfinder")
+    ));
+
+    @Override
+    public List<TestResourceEntry> testResources() {
+        return List.of(dbResource);
+    }
+
+    @Override
+    public String getConfigProfile() {
+        return "test";
+    }
+}

--- a/src/test/java/io/tackle/pathfinder/controllers/AssessmentsResourceTest.java
+++ b/src/test/java/io/tackle/pathfinder/controllers/AssessmentsResourceTest.java
@@ -10,6 +10,7 @@ import io.restassured.response.ValidatableResponse;
 import io.tackle.commons.testcontainers.KeycloakTestResource;
 import io.tackle.commons.testcontainers.PostgreSQLDatabaseTestResource;
 import io.tackle.commons.tests.SecuredResourceTest;
+import io.tackle.pathfinder.AbstractResourceTest;
 import io.tackle.pathfinder.dto.*;
 import io.tackle.pathfinder.model.Risk;
 import io.tackle.pathfinder.model.assessment.Assessment;
@@ -20,6 +21,7 @@ import io.tackle.pathfinder.model.assessment.AssessmentStakeholdergroup;
 import io.tackle.pathfinder.model.questionnaire.Questionnaire;
 import io.tackle.pathfinder.services.AssessmentSvc;
 import lombok.extern.java.Log;
+import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.context.ManagedExecutor;
 import org.junit.jupiter.api.BeforeEach;
@@ -58,7 +60,7 @@ import static org.hamcrest.Matchers.is;
         }
 )
 @Log
-public class AssessmentsResourceTest extends SecuredResourceTest {
+public class AssessmentsResourceTest extends AbstractResourceTest {
 	@Inject
 	AssessmentSvc assessmentSvc;
 
@@ -1334,6 +1336,12 @@ public class AssessmentsResourceTest extends SecuredResourceTest {
 
 	@Test
 	public void given_AssessmentAndTranslations_when_TranslationDeleted_then_ThatConceptHasTheNotTranslatedVallue() {
+		Config config = ConfigProvider.getConfig();
+		Boolean authorizationDisabled = config.getValue("pathfinder.disable.authorization", Boolean.class);
+		if (authorizationDisabled) {
+			return;
+		}
+
 		String KEYCLOAK_SERVER_URL = ConfigProvider.getConfig().getOptionalValue("quarkus.oidc.auth-server-url", String.class).orElse("http://localhost:8180/auth");
 		String ACCESS_TOKEN_JDOE = RestAssured.given().relaxedHTTPSValidation()
 			.auth().preemptive()

--- a/src/test/java/io/tackle/pathfinder/controllers/AssessmentsResourceTest.java
+++ b/src/test/java/io/tackle/pathfinder/controllers/AssessmentsResourceTest.java
@@ -1,17 +1,25 @@
 package io.tackle.pathfinder.controllers;
 
 import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
-import io.quarkus.test.common.QuarkusTestResource;
-import io.quarkus.test.common.ResourceArg;
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.restassured.response.ValidatableResponse;
-import io.tackle.commons.testcontainers.KeycloakTestResource;
-import io.tackle.commons.testcontainers.PostgreSQLDatabaseTestResource;
-import io.tackle.commons.tests.SecuredResourceTest;
 import io.tackle.pathfinder.AbstractResourceTest;
-import io.tackle.pathfinder.dto.*;
+import io.tackle.pathfinder.DefaultTestProfile;
+import io.tackle.pathfinder.dto.ApplicationDto;
+import io.tackle.pathfinder.dto.AssessmentBulkDto;
+import io.tackle.pathfinder.dto.AssessmentBulkPostDto;
+import io.tackle.pathfinder.dto.AssessmentCategoryDto;
+import io.tackle.pathfinder.dto.AssessmentDto;
+import io.tackle.pathfinder.dto.AssessmentHeaderDto;
+import io.tackle.pathfinder.dto.AssessmentQuestionDto;
+import io.tackle.pathfinder.dto.AssessmentQuestionOptionDto;
+import io.tackle.pathfinder.dto.AssessmentQuestionnaireDto;
+import io.tackle.pathfinder.dto.AssessmentStatus;
+import io.tackle.pathfinder.dto.LandscapeDto;
+import io.tackle.pathfinder.dto.RiskLineDto;
 import io.tackle.pathfinder.model.Risk;
 import io.tackle.pathfinder.model.assessment.Assessment;
 import io.tackle.pathfinder.model.assessment.AssessmentCategory;
@@ -21,18 +29,22 @@ import io.tackle.pathfinder.model.assessment.AssessmentStakeholdergroup;
 import io.tackle.pathfinder.model.questionnaire.Questionnaire;
 import io.tackle.pathfinder.services.AssessmentSvc;
 import lombok.extern.java.Log;
+import org.apache.commons.lang3.StringUtils;
+import org.awaitility.Awaitility;
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.context.ManagedExecutor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.apache.commons.lang3.StringUtils;
-import org.awaitility.Awaitility;
-
 
 import javax.inject.Inject;
-import javax.transaction.*;
-
+import javax.transaction.HeuristicMixedException;
+import javax.transaction.HeuristicRollbackException;
+import javax.transaction.NotSupportedException;
+import javax.transaction.RollbackException;
+import javax.transaction.SystemException;
+import javax.transaction.Transactional;
+import javax.transaction.UserTransaction;
 import java.time.Duration;
 import java.time.LocalTime;
 import java.util.List;
@@ -46,19 +58,7 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
 
 @QuarkusTest
-@QuarkusTestResource(value = PostgreSQLDatabaseTestResource.class,
-        initArgs = {
-                @ResourceArg(name = PostgreSQLDatabaseTestResource.DB_NAME, value = "pathfinder_db"),
-                @ResourceArg(name = PostgreSQLDatabaseTestResource.USER, value = "pathfinder"),
-                @ResourceArg(name = PostgreSQLDatabaseTestResource.PASSWORD, value = "pathfinder")
-        }
-)
-@QuarkusTestResource(value = KeycloakTestResource.class,
-        initArgs = {
-                @ResourceArg(name = KeycloakTestResource.IMPORT_REALM_JSON_PATH, value = "keycloak/quarkus-realm.json"),
-                @ResourceArg(name = KeycloakTestResource.REALM_NAME, value = "quarkus")
-        }
-)
+@TestProfile(DefaultTestProfile.class)
 @Log
 public class AssessmentsResourceTest extends AbstractResourceTest {
 	@Inject

--- a/src/test/java/io/tackle/pathfinder/controllers/NoAuthResourceTest.java
+++ b/src/test/java/io/tackle/pathfinder/controllers/NoAuthResourceTest.java
@@ -1,0 +1,109 @@
+package io.tackle.pathfinder.controllers;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import io.restassured.response.ValidatableResponse;
+import io.tackle.pathfinder.AbstractResourceTest;
+import io.tackle.pathfinder.DefaultTestProfile;
+import io.tackle.pathfinder.NoAuthTestProfile;
+import io.tackle.pathfinder.dto.ApplicationDto;
+import io.tackle.pathfinder.dto.AssessmentBulkDto;
+import io.tackle.pathfinder.dto.AssessmentBulkPostDto;
+import io.tackle.pathfinder.dto.AssessmentCategoryDto;
+import io.tackle.pathfinder.dto.AssessmentDto;
+import io.tackle.pathfinder.dto.AssessmentHeaderDto;
+import io.tackle.pathfinder.dto.AssessmentQuestionDto;
+import io.tackle.pathfinder.dto.AssessmentQuestionOptionDto;
+import io.tackle.pathfinder.dto.AssessmentQuestionnaireDto;
+import io.tackle.pathfinder.dto.AssessmentStatus;
+import io.tackle.pathfinder.dto.LandscapeDto;
+import io.tackle.pathfinder.dto.RiskLineDto;
+import io.tackle.pathfinder.dto.questionnaire.QuestionnaireHeaderDto;
+import io.tackle.pathfinder.model.Risk;
+import io.tackle.pathfinder.model.assessment.Assessment;
+import io.tackle.pathfinder.model.assessment.AssessmentCategory;
+import io.tackle.pathfinder.model.assessment.AssessmentSingleOption;
+import io.tackle.pathfinder.model.assessment.AssessmentStakeholder;
+import io.tackle.pathfinder.model.assessment.AssessmentStakeholdergroup;
+import io.tackle.pathfinder.model.questionnaire.Questionnaire;
+import io.tackle.pathfinder.services.AssessmentSvc;
+import lombok.extern.java.Log;
+import org.apache.commons.lang3.StringUtils;
+import org.awaitility.Awaitility;
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.eclipse.microprofile.context.ManagedExecutor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import javax.inject.Inject;
+import javax.transaction.HeuristicMixedException;
+import javax.transaction.HeuristicRollbackException;
+import javax.transaction.NotSupportedException;
+import javax.transaction.RollbackException;
+import javax.transaction.SystemException;
+import javax.transaction.Transactional;
+import javax.transaction.UserTransaction;
+import java.time.Duration;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * None of the requests in this test should have authentication but still return the expected results
+ */
+@QuarkusTest
+@TestProfile(NoAuthTestProfile.class)
+@Log
+public class NoAuthResourceTest {
+
+    @Inject
+    AssessmentSvc assessmentSvc;
+
+    @BeforeEach
+    @Transactional
+    public void init() {
+        Assessment.streamAll().forEach(PanacheEntityBase::delete);
+    }
+
+    @Test
+    public void getAssessments() {
+        given()
+                .queryParam("applicationId", "20")
+                .when()
+                .get("/assessments")
+                .then()
+                .statusCode(200);
+    }
+
+    @Test
+    public void getAssessmentById() {
+        AssessmentHeaderDto assessment = assessmentSvc.newAssessment(null, 20L);
+
+        given()
+                .when()
+                .get("/assessments/" + assessment.getId())
+                .then()
+                .statusCode(200);
+    }
+
+    @Test
+    public void getQuestionnaires() {
+        given()
+                .when()
+                .get("/questionnaires")
+                .then()
+                .statusCode(200);
+    }
+
+}

--- a/src/test/java/io/tackle/pathfinder/controllers/QuestionnairesResourceTest.java
+++ b/src/test/java/io/tackle/pathfinder/controllers/QuestionnairesResourceTest.java
@@ -1,24 +1,25 @@
 package io.tackle.pathfinder.controllers;
 
 import io.quarkus.test.junit.QuarkusTest;
-import io.tackle.commons.tests.SecuredResourceTest;
-import io.tackle.pathfinder.dto.AssessmentHeaderDto;
-import io.tackle.pathfinder.dto.AssessmentStatus;
+import io.tackle.pathfinder.AbstractResourceTest;
 import io.tackle.pathfinder.dto.questionnaire.QuestionnaireHeaderDto;
 import io.tackle.pathfinder.model.questionnaire.Questionnaire;
-import io.tackle.pathfinder.services.QuestionnaireSvc;
 import io.tackle.pathfinder.services.TranslatorSvc;
 import org.junit.jupiter.api.Test;
 
 import javax.inject.Inject;
-import javax.transaction.*;
+import javax.transaction.HeuristicMixedException;
+import javax.transaction.HeuristicRollbackException;
+import javax.transaction.NotSupportedException;
+import javax.transaction.RollbackException;
+import javax.transaction.SystemException;
+import javax.transaction.UserTransaction;
 
 import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 @QuarkusTest
-public class QuestionnairesResourceTest extends SecuredResourceTest {
+public class QuestionnairesResourceTest extends AbstractResourceTest {
     @Inject
     TranslatorSvc translatorSvc;
 

--- a/src/test/java/io/tackle/pathfinder/controllers/QuestionnairesResourceTest.java
+++ b/src/test/java/io/tackle/pathfinder/controllers/QuestionnairesResourceTest.java
@@ -1,7 +1,9 @@
 package io.tackle.pathfinder.controllers;
 
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
 import io.tackle.pathfinder.AbstractResourceTest;
+import io.tackle.pathfinder.DefaultTestProfile;
 import io.tackle.pathfinder.dto.questionnaire.QuestionnaireHeaderDto;
 import io.tackle.pathfinder.model.questionnaire.Questionnaire;
 import io.tackle.pathfinder.services.TranslatorSvc;
@@ -19,6 +21,7 @@ import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @QuarkusTest
+@TestProfile(DefaultTestProfile.class)
 public class QuestionnairesResourceTest extends AbstractResourceTest {
     @Inject
     TranslatorSvc translatorSvc;

--- a/src/test/java/io/tackle/pathfinder/controllers/TranslatorResourceTest.java
+++ b/src/test/java/io/tackle/pathfinder/controllers/TranslatorResourceTest.java
@@ -6,7 +6,7 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.http.ContentType;
 import io.tackle.commons.testcontainers.KeycloakTestResource;
 import io.tackle.commons.testcontainers.PostgreSQLDatabaseTestResource;
-import io.tackle.commons.tests.SecuredResourceTest;
+import io.tackle.pathfinder.AbstractResourceTest;
 import io.tackle.pathfinder.dto.AssessmentCategoryDto;
 import io.tackle.pathfinder.dto.AssessmentDto;
 import io.tackle.pathfinder.dto.AssessmentHeaderDto;
@@ -38,7 +38,7 @@ import static org.assertj.core.api.Assertions.assertThat;
         }
 )
 @Log
-class TranslatorResourceTest extends SecuredResourceTest {
+class TranslatorResourceTest extends AbstractResourceTest {
 
     @Inject
     AssessmentSvc assessmentSvc;

--- a/src/test/java/io/tackle/pathfinder/controllers/TranslatorResourceTest.java
+++ b/src/test/java/io/tackle/pathfinder/controllers/TranslatorResourceTest.java
@@ -1,12 +1,10 @@
 package io.tackle.pathfinder.controllers;
 
-import io.quarkus.test.common.QuarkusTestResource;
-import io.quarkus.test.common.ResourceArg;
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
 import io.restassured.http.ContentType;
-import io.tackle.commons.testcontainers.KeycloakTestResource;
-import io.tackle.commons.testcontainers.PostgreSQLDatabaseTestResource;
 import io.tackle.pathfinder.AbstractResourceTest;
+import io.tackle.pathfinder.DefaultTestProfile;
 import io.tackle.pathfinder.dto.AssessmentCategoryDto;
 import io.tackle.pathfinder.dto.AssessmentDto;
 import io.tackle.pathfinder.dto.AssessmentHeaderDto;
@@ -24,19 +22,7 @@ import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @QuarkusTest
-@QuarkusTestResource(value = PostgreSQLDatabaseTestResource.class,
-        initArgs = {
-                @ResourceArg(name = PostgreSQLDatabaseTestResource.DB_NAME, value = "pathfinder_db"),
-                @ResourceArg(name = PostgreSQLDatabaseTestResource.USER, value = "pathfinder"),
-                @ResourceArg(name = PostgreSQLDatabaseTestResource.PASSWORD, value = "pathfinder")
-        }
-)
-@QuarkusTestResource(value = KeycloakTestResource.class,
-        initArgs = {
-                @ResourceArg(name = KeycloakTestResource.IMPORT_REALM_JSON_PATH, value = "keycloak/quarkus-realm.json"),
-                @ResourceArg(name = KeycloakTestResource.REALM_NAME, value = "quarkus")
-        }
-)
+@TestProfile(DefaultTestProfile.class)
 @Log
 class TranslatorResourceTest extends AbstractResourceTest {
 

--- a/src/test/java/io/tackle/pathfinder/services/AssessmentSvcTest.java
+++ b/src/test/java/io/tackle/pathfinder/services/AssessmentSvcTest.java
@@ -1,14 +1,20 @@
 package io.tackle.pathfinder.services;
 
-import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
 import io.quarkus.panache.mock.PanacheMock;
 import io.quarkus.security.identity.SecurityIdentity;
-import io.quarkus.test.common.QuarkusTestResource;
-import io.quarkus.test.common.ResourceArg;
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
 import io.quarkus.test.junit.mockito.InjectMock;
-import io.tackle.commons.testcontainers.PostgreSQLDatabaseTestResource;
-import io.tackle.pathfinder.dto.*;
+import io.tackle.pathfinder.DefaultTestProfile;
+import io.tackle.pathfinder.dto.AdoptionCandidateDto;
+import io.tackle.pathfinder.dto.AssessmentCategoryDto;
+import io.tackle.pathfinder.dto.AssessmentDto;
+import io.tackle.pathfinder.dto.AssessmentHeaderDto;
+import io.tackle.pathfinder.dto.AssessmentQuestionDto;
+import io.tackle.pathfinder.dto.AssessmentQuestionOptionDto;
+import io.tackle.pathfinder.dto.AssessmentStatus;
+import io.tackle.pathfinder.dto.LandscapeDto;
+import io.tackle.pathfinder.dto.RiskLineDto;
 import io.tackle.pathfinder.mapper.AssessmentMapper;
 import io.tackle.pathfinder.model.QuestionType;
 import io.tackle.pathfinder.model.Risk;
@@ -30,11 +36,14 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import javax.inject.Inject;
-import javax.transaction.*;
+import javax.transaction.HeuristicMixedException;
+import javax.transaction.HeuristicRollbackException;
+import javax.transaction.NotSupportedException;
+import javax.transaction.RollbackException;
+import javax.transaction.SystemException;
+import javax.transaction.Transactional;
+import javax.transaction.UserTransaction;
 import javax.ws.rs.BadRequestException;
-import javax.ws.rs.core.SecurityContext;
-
-import java.security.Principal;
 import java.time.Duration;
 import java.util.Comparator;
 import java.util.List;
@@ -44,16 +53,11 @@ import java.util.concurrent.CompletionException;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-@QuarkusTestResource(value = PostgreSQLDatabaseTestResource.class,
-        initArgs = {
-                @ResourceArg(name = PostgreSQLDatabaseTestResource.DB_NAME, value = "pathfinder_db"),
-                @ResourceArg(name = PostgreSQLDatabaseTestResource.USER, value = "pathfinder"),
-                @ResourceArg(name = PostgreSQLDatabaseTestResource.PASSWORD, value = "pathfinder")
-        }
-)
 @QuarkusTest
+@TestProfile(DefaultTestProfile.class)
 @Log
 public class AssessmentSvcTest {
     @Inject

--- a/src/test/java/io/tackle/pathfinder/services/QuestionnaireSvcTest.java
+++ b/src/test/java/io/tackle/pathfinder/services/QuestionnaireSvcTest.java
@@ -1,19 +1,20 @@
 package io.tackle.pathfinder.services;
 
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.tackle.pathfinder.DefaultTestProfile;
 import io.tackle.pathfinder.dto.questionnaire.QuestionnaireHeaderDto;
 import io.tackle.pathfinder.model.questionnaire.Questionnaire;
 import org.assertj.core.groups.Tuple;
 import org.junit.jupiter.api.Test;
 
 import javax.inject.Inject;
-
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 @QuarkusTest
+@TestProfile(DefaultTestProfile.class)
 class QuestionnaireSvcTest {
     @Inject
     QuestionnaireSvc questionnaireSvc;

--- a/src/test/java/io/tackle/pathfinder/services/TranslatorSvcTest.java
+++ b/src/test/java/io/tackle/pathfinder/services/TranslatorSvcTest.java
@@ -1,10 +1,9 @@
 package io.tackle.pathfinder.services;
 
 import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
-import io.quarkus.test.common.QuarkusTestResource;
-import io.quarkus.test.common.ResourceArg;
 import io.quarkus.test.junit.QuarkusTest;
-import io.tackle.commons.testcontainers.PostgreSQLDatabaseTestResource;
+import io.quarkus.test.junit.TestProfile;
+import io.tackle.pathfinder.DefaultTestProfile;
 import io.tackle.pathfinder.dto.AssessmentDto;
 import io.tackle.pathfinder.dto.AssessmentHeaderDto;
 import io.tackle.pathfinder.dto.AssessmentQuestionDto;
@@ -19,16 +18,10 @@ import javax.inject.Inject;
 import javax.transaction.Transactional;
 import java.util.List;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
-@QuarkusTestResource(value = PostgreSQLDatabaseTestResource.class,
-    initArgs = {
-        @ResourceArg(name = PostgreSQLDatabaseTestResource.DB_NAME, value = "pathfinder_db"),
-        @ResourceArg(name = PostgreSQLDatabaseTestResource.USER, value = "pathfinder"),
-        @ResourceArg(name = PostgreSQLDatabaseTestResource.PASSWORD, value = "pathfinder")
-    }
-)
 @QuarkusTest
+@TestProfile(DefaultTestProfile.class)
 public class TranslatorSvcTest {
     @Inject
     TranslatorSvc translatorSvc;


### PR DESCRIPTION
https://issues.redhat.com/browse/TACKLE-419

To enable Pathfinder to run without Keycloak an ENV variable needs to be set
- `QUARKUS_PROFILE=noauth`