### PR TITLE
bulk_delete: new endpoint for bulk delete of assessments

### DIFF
--- a/.github/scripts/check_api.sh
+++ b/.github/scripts/check_api.sh
@@ -378,29 +378,7 @@ test "$req_get_delete_assessment" = "204"
 
 echo
 echo
-echo '22 >>> Given rolled back deletion of assessments, request assessments by application id and make sure they are still there'
-req_find_delete_assessment=$(curl -X GET "http://$api_ip/pathfinder/assessments?applicationId=$applicationSource" -H 'Accept: application/json' \
-            -H "Authorization: Bearer $access_token" -s)
-test "1" = "$(echo $req_find_delete_assessment | jq 'length')"
-
-
-req_find_delete_assessment=$(curl -X GET "http://$api_ip/pathfinder/assessments?applicationId=$applicationTarget" -H 'Accept: application/json' \
-            -H "Authorization: Bearer $access_token" -s)
-test "1" = "$(echo $req_find_delete_assessment | jq 'length')"
-
-echo
-echo
-echo '23 >>> Bulk delete assessments passing in a list of applicationIds with assessments and receive 204 as return code'
-req_get_delete_assessment=$(curl -X DELETE "http://$api_ip/pathfinder/assessments/bulkDelete" -H 'Accept: application/json' \
-            -H "Authorization: Bearer $access_token" \
-            -H 'Content-Type: application/json' \
-            -d "[{\"applicationId\": $applicationSource}, {\"applicationId\": $applicationTarget}]" \
-             -w "%{http_code}")
-test "$req_get_delete_assessment" = "204"
-
-echo
-echo
-echo '24 >>> Given a deleted assessment, request assessments by application id and receive empty list'
+echo '22>>> Given a deleted assessment, request assessments by application id and receive empty list'
 req_find_delete_assessment=$(curl -X GET "http://$api_ip/pathfinder/assessments?applicationId=$applicationSource" -H 'Accept: application/json' \
             -H "Authorization: Bearer $access_token" -w "%{http_code}")
 test "$req_find_delete_assessment" = "[]200"

--- a/.github/scripts/check_api.sh
+++ b/.github/scripts/check_api.sh
@@ -372,7 +372,7 @@ echo '21 >>> Bulk delete assessments passing in a list of applicationIds, one of
 req_get_delete_assessment=$(curl -X DELETE "http://$api_ip/pathfinder/assessments/bulkDelete" -H 'Accept: application/json' \
             -H "Authorization: Bearer $access_token" \
             -H 'Content-Type: application/json' \
-            -d "{\"applicationIds\": [111111111,$applicationSource},$applicationTarget]}" \
+            -d "{\"applicationIds\": [111111111,$applicationSource,$applicationTarget]}" \
              -w "%{http_code}")
 test "$req_get_delete_assessment" = "204"
 

--- a/.github/scripts/check_api.sh
+++ b/.github/scripts/check_api.sh
@@ -381,12 +381,12 @@ echo
 echo '22 >>> Given rolled back deletion of assessments, request assessments by application id and make sure they are still there'
 req_find_delete_assessment=$(curl -X GET "http://$api_ip/pathfinder/assessments?applicationId=$applicationSource" -H 'Accept: application/json' \
             -H "Authorization: Bearer $access_token" -s)
-test $(echo $req_find_delete_assessment | jq '.assessments | length') = 1
+test "1" = "$(echo $req_find_delete_assessment | jq 'length')"
 
 
 req_find_delete_assessment=$(curl -X GET "http://$api_ip/pathfinder/assessments?applicationId=$applicationTarget" -H 'Accept: application/json' \
             -H "Authorization: Bearer $access_token" -s)
-test $(echo $req_find_delete_assessment | jq '.assessments | length') = 1
+test "1" = "$(echo $req_find_delete_assessment | jq 'length')"
 
 echo
 echo

--- a/.github/scripts/check_api.sh
+++ b/.github/scripts/check_api.sh
@@ -366,5 +366,26 @@ test $(echo $req_bulk_applications | jq '.assessments[] | select(.applicationId 
 test $(echo $req_bulk_applications | jq '.assessments[] | select(.applicationId == 12) | .status ') = '"STARTED"'
 test $(echo $req_bulk_applications | jq '.assessments[] | select(.applicationId == 325100) | .status ') = '"STARTED"'
 
+echo
+echo
+echo '21 >>> Bulk delete assessments passing in a list of applicationIds and receive 204 as return code'
+req_get_delete_assessment=$(curl -X POST "http://$api_ip/pathfinder/assessments/bulkDelete" -H 'Accept: application/json' \
+            -H "Authorization: Bearer $access_token" \
+            -d "[{\"applicationId\": $applicationSource}, {\"applicationId\": $applicationTarget}]" \
+             -w "%{http_code}")
+test "$req_get_delete_assessment" = "204"
+
+echo
+echo
+echo '22 >>> Given a deleted assessment, request assessments by application id and receive empty list'
+req_find_delete_assessment=$(curl -X GET "http://$api_ip/pathfinder/assessments?applicationId=$applicationSource" -H 'Accept: application/json' \
+            -H "Authorization: Bearer $access_token" -w "%{http_code}")
+test "$req_find_delete_assessment" = "[]200"
+
+
+req_find_delete_assessment=$(curl -X GET "http://$api_ip/pathfinder/assessments?applicationId=$applicationTarget" -H 'Accept: application/json' \
+            -H "Authorization: Bearer $access_token" -w "%{http_code}")
+test "$req_find_delete_assessment" = "[]200"
+
 
 echo " +++++ API CHECK SUCCESSFUL ++++++"

--- a/.github/scripts/check_api.sh
+++ b/.github/scripts/check_api.sh
@@ -368,7 +368,29 @@ test $(echo $req_bulk_applications | jq '.assessments[] | select(.applicationId 
 
 echo
 echo
-echo '21 >>> Bulk delete assessments passing in a list of applicationIds and receive 204 as return code'
+echo '21 >>> Bulk delete assessments passing in a list of applicationIds, one of which doesnt exist and receive 204 as return code'
+req_get_delete_assessment=$(curl -X DELETE "http://$api_ip/pathfinder/assessments/bulkDelete" -H 'Accept: application/json' \
+            -H "Authorization: Bearer $access_token" \
+            -H 'Content-Type: application/json' \
+            -d "[{\"applicationId\": 111111111}, {\"applicationId\": $applicationSource}, {\"applicationId\": $applicationTarget}]" \
+             -w "%{http_code}")
+test "$req_get_delete_assessment" = "204"
+
+echo
+echo
+echo '22 >>> Given rolled back deletion of assessments, request assessments by application id and make sure they are still there'
+req_find_delete_assessment=$(curl -X GET "http://$api_ip/pathfinder/assessments?applicationId=$applicationSource" -H 'Accept: application/json' \
+            -H "Authorization: Bearer $access_token" -s)
+test $(echo $req_find_delete_assessment | jq '.assessments | length') = 1
+
+
+req_find_delete_assessment=$(curl -X GET "http://$api_ip/pathfinder/assessments?applicationId=$applicationTarget" -H 'Accept: application/json' \
+            -H "Authorization: Bearer $access_token" -s)
+test $(echo $req_find_delete_assessment | jq '.assessments | length') = 1
+
+echo
+echo
+echo '23 >>> Bulk delete assessments passing in a list of applicationIds with assessments and receive 204 as return code'
 req_get_delete_assessment=$(curl -X DELETE "http://$api_ip/pathfinder/assessments/bulkDelete" -H 'Accept: application/json' \
             -H "Authorization: Bearer $access_token" \
             -H 'Content-Type: application/json' \
@@ -378,7 +400,7 @@ test "$req_get_delete_assessment" = "204"
 
 echo
 echo
-echo '22 >>> Given a deleted assessment, request assessments by application id and receive empty list'
+echo '24 >>> Given a deleted assessment, request assessments by application id and receive empty list'
 req_find_delete_assessment=$(curl -X GET "http://$api_ip/pathfinder/assessments?applicationId=$applicationSource" -H 'Accept: application/json' \
             -H "Authorization: Bearer $access_token" -w "%{http_code}")
 test "$req_find_delete_assessment" = "[]200"

--- a/.github/scripts/check_api.sh
+++ b/.github/scripts/check_api.sh
@@ -369,7 +369,7 @@ test $(echo $req_bulk_applications | jq '.assessments[] | select(.applicationId 
 echo
 echo
 echo '21 >>> Bulk delete assessments passing in a list of applicationIds and receive 204 as return code'
-req_get_delete_assessment=$(curl -X POST "http://$api_ip/pathfinder/assessments/bulkDelete" -H 'Accept: application/json' \
+req_get_delete_assessment=$(curl -X DELETE "http://$api_ip/pathfinder/assessments/bulkDelete" -H 'Accept: application/json' \
             -H "Authorization: Bearer $access_token" \
             -H 'Content-Type: application/json' \
             -d "[{\"applicationId\": $applicationSource}, {\"applicationId\": $applicationTarget}]" \

--- a/.github/scripts/check_api.sh
+++ b/.github/scripts/check_api.sh
@@ -370,8 +370,8 @@ echo
 echo
 echo '21 >>> Bulk delete assessments passing in a list of applicationIds and receive 204 as return code'
 req_get_delete_assessment=$(curl -X POST "http://$api_ip/pathfinder/assessments/bulkDelete" -H 'Accept: application/json' \
-            -H 'Content-Type: application/json' \
             -H "Authorization: Bearer $access_token" \
+            -H 'Content-Type: application/json' \
             -d "[{\"applicationId\": $applicationSource}, {\"applicationId\": $applicationTarget}]" \
              -w "%{http_code}")
 test "$req_get_delete_assessment" = "204"

--- a/.github/scripts/check_api.sh
+++ b/.github/scripts/check_api.sh
@@ -372,7 +372,7 @@ echo '21 >>> Bulk delete assessments passing in a list of applicationIds, one of
 req_get_delete_assessment=$(curl -X DELETE "http://$api_ip/pathfinder/assessments/bulkDelete" -H 'Accept: application/json' \
             -H "Authorization: Bearer $access_token" \
             -H 'Content-Type: application/json' \
-            -d "[{\"applicationId\": 111111111}, {\"applicationId\": $applicationSource}, {\"applicationId\": $applicationTarget}]" \
+            -d "{\"applicationIds\": [111111111,$applicationSource},$applicationTarget]}" \
              -w "%{http_code}")
 test "$req_get_delete_assessment" = "204"
 

--- a/.github/scripts/check_api.sh
+++ b/.github/scripts/check_api.sh
@@ -370,6 +370,7 @@ echo
 echo
 echo '21 >>> Bulk delete assessments passing in a list of applicationIds and receive 204 as return code'
 req_get_delete_assessment=$(curl -X POST "http://$api_ip/pathfinder/assessments/bulkDelete" -H 'Accept: application/json' \
+            -H 'Content-Type: application/json' \
             -H "Authorization: Bearer $access_token" \
             -d "[{\"applicationId\": $applicationSource}, {\"applicationId\": $applicationTarget}]" \
              -w "%{http_code}")

--- a/src/main/java/io/tackle/pathfinder/controllers/AssessmentsResource.java
+++ b/src/main/java/io/tackle/pathfinder/controllers/AssessmentsResource.java
@@ -144,4 +144,13 @@ public class AssessmentsResource {
   public AssessmentBulkDto bulkGet(@NotNull @PathParam("bulkId") Long bulkId) {
     return assessmentSvc.bulkGet(bulkId);
   }
+
+  @POST
+  @Path("/bulkDelete")
+  @Produces("application/json")
+  @Consumes("application/json")
+  public Response bulkDelete(@NotNull @Valid List<ApplicationDto> applicationId) {
+    assessmentSvc.bulkDeleteAssessments(applicationId.stream().map(ApplicationDto::getApplicationId).collect(Collectors.toList()));
+    return Response.ok().status(Response.Status.NO_CONTENT).build();
+  }
 }

--- a/src/main/java/io/tackle/pathfinder/controllers/AssessmentsResource.java
+++ b/src/main/java/io/tackle/pathfinder/controllers/AssessmentsResource.java
@@ -145,7 +145,7 @@ public class AssessmentsResource {
     return assessmentSvc.bulkGet(bulkId);
   }
 
-  @POST
+  @DELETE
   @Path("/bulkDelete")
   @Produces("application/json")
   @Consumes("application/json")

--- a/src/main/java/io/tackle/pathfinder/controllers/AssessmentsResource.java
+++ b/src/main/java/io/tackle/pathfinder/controllers/AssessmentsResource.java
@@ -30,6 +30,8 @@ import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.eclipse.microprofile.jwt.JsonWebToken;
@@ -149,8 +151,8 @@ public class AssessmentsResource {
   @Path("/bulkDelete")
   @Produces("application/json")
   @Consumes("application/json")
-  public Response bulkDelete(@NotNull @Valid List<ApplicationDto> applicationId) {
-    assessmentSvc.bulkDeleteAssessments(applicationId.stream().map(ApplicationDto::getApplicationId).collect(Collectors.toList()));
+  public Response bulkDelete(@NotNull @Valid LinkedHashMap<String, List<Long>> applicationIds) {
+    assessmentSvc.bulkDeleteAssessments(applicationIds.get("applicationIds"));
     return Response.ok().status(Response.Status.NO_CONTENT).build();
   }
 }

--- a/src/main/java/io/tackle/pathfinder/controllers/AssessmentsResource.java
+++ b/src/main/java/io/tackle/pathfinder/controllers/AssessmentsResource.java
@@ -30,8 +30,6 @@ import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
-import java.util.Arrays;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.eclipse.microprofile.jwt.JsonWebToken;
@@ -151,8 +149,8 @@ public class AssessmentsResource {
   @Path("/bulkDelete")
   @Produces("application/json")
   @Consumes("application/json")
-  public Response bulkDelete(@NotNull @Valid LinkedHashMap<String, List<Long>> applicationIds) {
-    assessmentSvc.bulkDeleteAssessments(applicationIds.get("applicationIds"));
+  public Response bulkDelete(@NotNull @Valid ApplicationBulkDto applicationBulkDto) {
+    assessmentSvc.bulkDeleteAssessments(applicationBulkDto.getApplicationIds());
     return Response.ok().status(Response.Status.NO_CONTENT).build();
   }
 }

--- a/src/main/java/io/tackle/pathfinder/dto/ApplicationBulkDto.java
+++ b/src/main/java/io/tackle/pathfinder/dto/ApplicationBulkDto.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2021 the Konveyor Contributors (https://konveyor.io/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.tackle.pathfinder.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotNull;
+import java.util.List;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@RegisterForReflection
+public class ApplicationBulkDto {
+    /**
+     * 
+     * (Required)
+     * 
+     */
+    @JsonProperty("applicationIds")
+    @JsonPropertyDescription("")
+    @NotNull
+    private List<Long> applicationIds;
+}

--- a/src/main/java/io/tackle/pathfinder/services/AssessmentSvc.java
+++ b/src/main/java/io/tackle/pathfinder/services/AssessmentSvc.java
@@ -16,6 +16,7 @@
 package io.tackle.pathfinder.services;
 
 import com.google.common.util.concurrent.AtomicDouble;
+import io.quarkus.hibernate.orm.panache.PanacheQuery;
 import io.tackle.pathfinder.dto.*;
 import io.quarkus.security.identity.SecurityIdentity;
 import io.quarkus.vertx.ConsumeEvent;
@@ -314,6 +315,20 @@ public class AssessmentSvc {
         boolean deleted = Assessment.deleteById(assessment.id);
         log.log(Level.FINE, "Deleted assessment : " + assessmentId + " = " + deleted);
         if (!deleted) throw new BadRequestException();
+    }
+
+    @Transactional
+    public void bulkDeleteAssessments(@NotNull List <Long> applicationIds) {
+        applicationIds.forEach(applicationId -> {
+            PanacheQuery<Assessment> query = Assessment.find("application_id", applicationId);
+            List<Assessment> assessments = query.stream().collect(Collectors.toList());
+            assessments.forEach(assessment -> {
+                deleteAssessment(assessment.id);
+            });
+
+        });
+        //Assessment.delete("application_id in ?1",applicationIds);
+        //log.log(Level.FINE, "Deleted assessments for applicationIds : " + applicationIds.stream().map(x->String.valueOf(x)).collect(Collectors.joining(", ")));
     }
 
     public AssessmentBulkDto bulkCreateAssessments(Long fromAssessmentId, @NotNull @Valid List<Long> appList) throws NotSupportedException, SystemException, SecurityException, IllegalStateException, RollbackException, HeuristicMixedException, HeuristicRollbackException {

--- a/src/main/java/io/tackle/pathfinder/services/AssessmentSvc.java
+++ b/src/main/java/io/tackle/pathfinder/services/AssessmentSvc.java
@@ -327,6 +327,12 @@ public class AssessmentSvc {
             });
 
         });
+
+        /*
+            This approach (calling a delete method passing in a custom query)
+            was tried but it didn't work as cascade delete instructions on such methods are ignored by Panache.
+            See: https://github.com/quarkusio/quarkus/issues/13941#issuecomment-757500370
+        */
         //Assessment.delete("application_id in ?1",applicationIds);
         //log.log(Level.FINE, "Deleted assessments for applicationIds : " + applicationIds.stream().map(x->String.valueOf(x)).collect(Collectors.joining(", ")));
     }


### PR DESCRIPTION
If running this locally you can test by running a command of this form:

`curl -X POST "http://$api_ip/pathfinder/assessments/bulkDelete" -H 'Accept: application/json' \
            -H "Authorization: Bearer $access_token" \
            -H 'Content-Type: application/json' \
            -d "[{\"applicationId\": 1}, {\"applicationId\": 2}]"`